### PR TITLE
[RFC] vim-patch:8.1.0010 8.1.0252 8.1.0288 8.1.0330 8.1.0345 8.1.0407 8.1.0434 8.1.0469 8.1.0532 8.1.1006 8.1.1030 8.1.1062 8.1.1098 8.1.1112 8.1.1256

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4553,6 +4553,10 @@ getloclist({nr},[, {what}])				*getloclist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns the items listed in {what} as a dictionary. Refer to
 		|getqflist()| for the supported items in {what}.
+		If {what} contains 'filewinid', then returns the id of the
+		window used to display files from the location list. This
+		field is applicable only when called from a location list
+		window.
 
 getmatches()						*getmatches()*
 		Returns a |List| with all matches previously defined for the

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1163,11 +1163,13 @@ tag		command		action ~
 |:cNfile|	:cNf[ile]	go to last error in previous file
 |:cabbrev|	:ca[bbrev]	like ":abbreviate" but for Command-line mode
 |:cabclear|	:cabc[lear]	clear all abbreviations for Command-line mode
+|:cabove|	:cabo[ve]	go to error above current line
 |:caddbuffer|	:cad[dbuffer]	add errors from buffer
 |:caddexpr|	:cadde[xpr]	add errors from expr
 |:caddfile|	:caddf[ile]	add error message to current quickfix list
 |:call|		:cal[l]		call a function
 |:catch|	:cat[ch]	part of a :try command
+|:cbelow|	:cbe[low]	got to error below current line
 |:cbottom|	:cbo[ttom]	scroll to the bottom of the quickfix window
 |:cbuffer|	:cb[uffer]	parse error messages and jump to first error
 |:cc|		:cc		go to specific error
@@ -1324,12 +1326,14 @@ tag		command		action ~
 |:lNext|	:lN[ext]	go to previous entry in location list
 |:lNfile|	:lNf[ile]	go to last entry in previous file
 |:list|		:l[ist]		print lines
+|:labove|	:lab[ove]	go to location above current line
 |:laddexpr|	:lad[dexpr]	add locations from expr
 |:laddbuffer|	:laddb[uffer]	add locations from buffer
 |:laddfile|	:laddf[ile]	add locations to current location list
 |:last|		:la[st]		go to the last file in the argument list
 |:language|	:lan[guage]	set the language (locale)
 |:later|	:lat[er]	go to newer change, redo
+|:lbelow|	:lbe[low]	go to location below current line
 |:lbottom|	:lbo[ttom]	scroll to the bottom of the location window
 |:lbuffer|	:lb[uffer]	parse locations and jump to first location
 |:lcd|		:lc[d]		change directory locally

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -109,6 +109,36 @@ processing a quickfix or location list command, it will be aborted.
 			list for the current window is used instead of the
 			quickfix list.
 
+							*:cabo* *:cabove*
+:[count]cabo[ve]	Go to the [count] error above the current line in the
+			current buffer.  If [count] is omitted, then 1 is
+			used.  If there are no errors, then an error message
+			is displayed.  Assumes that the entries in a quickfix
+			list are sorted by their buffer number and line
+			number. If there are multiple errors on the same line,
+			then only the first entry is used.  If [count] exceeds
+			the number of entries above the current line, then the
+			first error in the file is selected.
+
+							*:lab* *:labove*
+:[count]lab[ove]	Same as ":cabove", except the location list for the
+			current window is used instead of the quickfix list.
+
+							*:cbe* *:cbelow*
+:[count]cbe[low]	Go to the [count] error below the current line in the
+			current buffer.  If [count] is omitted, then 1 is
+			used.  If there are no errors, then an error message
+			is displayed.  Assumes that the entries in a quickfix
+			list are sorted by their buffer number and line
+			number.  If there are multiple errors on the same
+			line, then only the first entry is used.  If [count]
+			exceeds the number of entries below the current line,
+			then the last error in the file is selected.
+
+							*:lbe* *:lbelow*
+:[count]lbe[low]	Same as ":cbelow", except the location list for the
+			current window is used instead of the quickfix list.
+
 							*:cnf* *:cnfile*
 :[count]cnf[ile][!]	Display the first error in the [count] next file in
 			the list that includes a file name.  If there are no

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -323,6 +323,12 @@ return {
     func='ex_abclear',
   },
   {
+    command='cabove',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
+  },
+  {
     command='caddbuffer',
     flags=bit.bor(RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
@@ -357,6 +363,12 @@ return {
     flags=bit.bor(BANG, RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
     func='ex_cbuffer',
+  },
+  {
+    command='cbelow',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
   },
   {
     command='cbottom',
@@ -1273,6 +1285,12 @@ return {
     func='ex_last',
   },
   {
+    command='labove',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
+  },
+  {
     command='language',
     flags=bit.bor(EXTRA, TRLBAR, CMDWIN),
     addr_type=ADDR_LINES,
@@ -1307,6 +1325,12 @@ return {
     flags=bit.bor(BANG, RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
     func='ex_cbuffer',
+  },
+  {
+    command='lbelow',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
   },
   {
     command='lbottom',

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -10299,3 +10299,13 @@ Dictionary commands_array(buf_T *buf)
   }
   return rv;
 }
+
+/*
+ * Returns TRUE if the supplied Ex cmdidx is for a location list command
+ * instead of a quickfix command.
+ */
+int is_loclist_cmd(int cmdidx) {
+  if (cmdidx < 0 || cmdidx >= CMD_SIZE)
+    return FALSE;
+  return cmdnames[cmdidx].cmd_name[0] == 'l';
+}

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -163,6 +163,10 @@ enum {
   QF_MULTISCAN = 5,
 };
 
+/*
+ * State information used to parse lines and add entries to a quickfix/location
+ * list.
+ */
 typedef struct {
   char_u *linebuf;
   size_t linelen;
@@ -266,100 +270,101 @@ static struct fmtpattern
 
 /*
  * Convert an errorformat pattern to a regular expression pattern.
- * See fmt_pat definition above for the list of supported patterns.
+ * See fmt_pat definition above for the list of supported patterns.  The
+ * pattern specifier is supplied in "efmpat".  The converted pattern is stored
+ * in "regpat".  Returns a pointer to the location after the pattern.
  */
-static char_u * fmtpat_to_regpat(
-    char_u *efmp,
-    efm_T *fmt_ptr,
+static char_u * efmpat_to_regpat(
+    char_u *efmpat,
+    char_u *regpat,
+    efm_T *efminfo,
     int	idx,
     int	round,
-    char_u *ptr,
     char_u *errmsg)
 {
   char_u *srcptr;
 
-  if (fmt_ptr->addr[idx]) {
+  if (efminfo->addr[idx]) {
     /* Each errorformat pattern can occur only once */
     snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-        _("E372: Too many %%%c in format string"), *efmp);
+        _("E372: Too many %%%c in format string"), *efmpat);
     EMSG(errmsg);
     return NULL;
   }
   if ((idx && idx < 6
-        && vim_strchr((char_u *)"DXOPQ", fmt_ptr->prefix) != NULL)
+        && vim_strchr((char_u *)"DXOPQ", efminfo->prefix) != NULL)
       || (idx == 6
-        && vim_strchr((char_u *)"OPQ", fmt_ptr->prefix) == NULL)) {
+        && vim_strchr((char_u *)"OPQ", efminfo->prefix) == NULL)) {
     snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-        _("E373: Unexpected %%%c in format string"), *efmp);
+        _("E373: Unexpected %%%c in format string"), *efmpat);
     EMSG(errmsg);
     return NULL;
   }
   ++round;
-  fmt_ptr->addr[idx] = (char_u)round;
-  *ptr++ = '\\';
-  *ptr++ = '(';
+  efminfo->addr[idx] = (char_u)round;
+  *regpat++ = '\\';
+  *regpat++ = '(';
 #ifdef BACKSLASH_IN_FILENAME
-  if (*efmp == 'f') {
+  if (*efmpat == 'f') {
     /* Also match "c:" in the file name, even when
      * checking for a colon next: "%f:".
      * "\%(\a:\)\=" */
-    STRCPY(ptr, "\\%(\\a:\\)\\=");
-    ptr += 10;
+    STRCPY(regpat, "\\%(\\a:\\)\\=");
+    regpat += 10;
   }
 #endif
-  if (*efmp == 'f' && efmp[1] != NUL) {
-    if (efmp[1] != '\\' && efmp[1] != '%') {
+  if (*efmpat == 'f' && efmpat[1] != NUL) {
+    if (efmpat[1] != '\\' && efmpat[1] != '%') {
       /* A file name may contain spaces, but this isn't
          + 	     * in "\f".  For "%f:%l:%m" there may be a ":" in
          + 	     * the file name.  Use ".\{-1,}x" instead (x is
          + 	     * the next character), the requirement that :999:
          + 	     * follows should work. */
-      STRCPY(ptr, ".\\{-1,}");
-      ptr += 7;
+      STRCPY(regpat, ".\\{-1,}");
+      regpat += 7;
     } else {
       /* File name followed by '\\' or '%': include as
          + 	     * many file name chars as possible. */
-      STRCPY(ptr, "\\f\\+");
-      ptr += 4;
+      STRCPY(regpat, "\\f\\+");
+      regpat += 4;
     }
   } else {
     srcptr = (char_u *)fmt_pat[idx].pattern;
-    while ((*ptr = *srcptr++) != NUL) {
-      ++ptr;
+    while ((*regpat = *srcptr++) != NUL) {
+      ++regpat;
     }
   }
-  *ptr++ = '\\';
-  *ptr++ = ')';
+  *regpat++ = '\\';
+  *regpat++ = ')';
 
-  return ptr;
+  return regpat;
 }
 
 /*
  * Convert a scanf like format in 'errorformat' to a regular expression.
+ * Returns a pointer to the location after the pattern.
  */
 static char_u * scanf_fmt_to_regpat(
+    char_u **pefmp,
     char_u *efm,
     int	len,
-    char_u **pefmp,
-    char_u *ptr,
+    char_u *regpat,
     char_u *errmsg)
 {
   char_u *efmp = *pefmp;
 
-  ++efmp;
-
   if (*efmp == '[' || *efmp == '\\') {
-    if ((*ptr++ = *efmp) == '[') { /* %*[^a-z0-9] etc. */
+    if ((*regpat++ = *efmp) == '[') { /* %*[^a-z0-9] etc. */
       if (efmp[1] == '^') {
         ++efmp;
-        *ptr++ = *efmp;
+        *regpat++ = *efmp;
       }
       if (efmp < efm + len) {
         ++efmp;
-        *ptr++ = *efmp;	    /* could be ']' */
+        *regpat++ = *efmp;	    /* could be ']' */
         while (efmp < efm + len) {
           efmp++;
-          if ((*ptr++ = *efmp) == ']') {
+          if ((*regpat++ = *efmp) == ']') {
             break;
           }
         }
@@ -371,10 +376,10 @@ static char_u * scanf_fmt_to_regpat(
     }
     else if (efmp < efm + len) { /* %*\D, %*\s etc. */
       ++efmp;
-      *ptr++ = *efmp;
+      *regpat++ = *efmp;
     }
-    *ptr++ = '\\';
-    *ptr++ = '+';
+    *regpat++ = '\\';
+    *regpat++ = '+';
   } else {
     /* TODO: scanf()-like: %*ud, %*3c, %*f, ... ? */
     snprintf((char *)errmsg, CMDBUFFSIZE + 1,
@@ -385,30 +390,27 @@ static char_u * scanf_fmt_to_regpat(
 
   *pefmp = efmp;
 
-  return ptr;
+  return regpat;
 }
 
 /*
  * Analyze/parse an errorformat prefix.
  */
-static int efm_analyze_prefix(char_u **pefmp, efm_T *fmt_ptr, char_u *errmsg) {
-  char_u *efmp = *pefmp;
+static char_u *efm_analyze_prefix(char_u *efmp, efm_T *efminfo, char_u *errmsg) {
 
   if (vim_strchr((char_u *)"+-", *efmp) != NULL) {
-    fmt_ptr->flags = *efmp++;
+    efminfo->flags = *efmp++;
   }
   if (vim_strchr((char_u *)"DXAEWICZGOPQ", *efmp) != NULL) {
-    fmt_ptr->prefix = *efmp;
+    efminfo->prefix = *efmp;
   } else {
     snprintf((char *)errmsg, CMDBUFFSIZE + 1,
         _("E376: Invalid %%%c in format string prefix"), *efmp);
     EMSG(errmsg);
-    return FAIL;
+    return NULL;
   }
 
-  *pefmp = efmp;
-
-  return OK;
+  return efmp;
 }
 
 
@@ -430,15 +432,16 @@ static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
         }
       }
       if (idx < FMT_PATTERNS) {
-        ptr = fmtpat_to_regpat(efmp, fmt_ptr, idx, round, ptr, errmsg);
+        ptr = efmpat_to_regpat(efmp, ptr, fmt_ptr, idx, round, errmsg);
         if (ptr == NULL) {
-          return -1;
+          return FAIL;
         }
         round++;
       } else if (*efmp == '*') {
-        ptr = scanf_fmt_to_regpat(efm, len, &efmp, ptr, errmsg);
+        ++efmp;
+        ptr = scanf_fmt_to_regpat(&efmp, efm, len, ptr, errmsg);
         if (ptr == NULL) {
-          return -1;
+          return FAIL;
         }
       } else if (vim_strchr((char_u *)"%\\.^$~[", *efmp) != NULL) {
         *ptr++ = *efmp;  // regexp magic characters
@@ -447,14 +450,19 @@ static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
       } else if (*efmp == '>') {
         fmt_ptr->conthere = true;
       } else if (efmp == efm + 1) {             // analyse prefix
-        if (efm_analyze_prefix(&efmp, fmt_ptr, errmsg) == FAIL) {
-          return -1;
+        /*
+         * prefix is allowed only at the beginning of the errorformat
+         * option part
+         */
+        efmp = efm_analyze_prefix(efmp, fmt_ptr, errmsg);
+        if (efmp == NULL) {
+          return FAIL;
         }
       } else {
         snprintf((char *)errmsg, CMDBUFFSIZE + 1,
                  _("E377: Invalid %%%c in format string"), *efmp);
         EMSG(errmsg);
-        return -1;
+        return FAIL;
       }
     } else {                    // copy normal character
       if (*efmp == '\\' && efmp + 1 < efm + len) {
@@ -470,7 +478,7 @@ static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
   *ptr++ = '$';
   *ptr = NUL;
 
-  return 0;
+  return OK;
 }
 
 static efm_T *fmt_start = NULL;  // cached across qf_parse_line() calls
@@ -486,7 +494,44 @@ static void free_efm_list(efm_T **efm_first)
   fmt_start = NULL;
 }
 
-// Parse 'errorformat' option
+/*
+ * Compute the size of the buffer used to convert a 'errorformat' pattern into
+ * a regular expression pattern.
+ */
+static size_t efm_regpat_bufsz(char_u *efm) {
+  size_t sz;
+
+  sz = (FMT_PATTERNS * 3) + (STRLEN(efm) << 2);
+  for (int i = FMT_PATTERNS - 1; i >= 0; ) {
+    sz += STRLEN(fmt_pat[i--].pattern);
+  }
+#ifdef BACKSLASH_IN_FILENAME
+  sz += 12; /* "%f" can become twelve chars longer (see efm_to_regpat) */
+#else
+  sz += 2; /* "%f" can become two chars longer */
+#endif
+
+  return sz;
+}
+
+/*
+ * Return the length of a 'errorformat' option part (separated by ",").
+ */
+static int efm_option_part_len(char_u *efm) {
+  int len;
+
+  for (len = 0; efm[len] != NUL && efm[len] != ','; ++len)
+    if (efm[len] == '\\' && efm[len + 1] != NUL)
+      ++len;
+
+  return len;
+}
+
+/*
+ * Parse the 'errorformat' option. Multiple parts in the 'errorformat' option
+ * are parsed and converted to regular expressions. Returns information about
+ * the parsed 'errorformat' option.
+ */
 static efm_T * parse_efm_option(char_u *efm)
 {
   efm_T *fmt_ptr = NULL;
@@ -498,16 +543,8 @@ static efm_T * parse_efm_option(char_u *efm)
   char_u *errmsg = xmalloc(errmsglen);
 
   // Get some space to modify the format string into.
-  size_t i = (FMT_PATTERNS * 3) + (STRLEN(efm) << 2);
-  for (int round = FMT_PATTERNS - 1; round >= 0; ) {
-    i += STRLEN(fmt_pat[round--].pattern);
-  }
-#ifdef BACKSLASH_IN_FILENAME
-  i += 12;  // "%f" can become twelve chars longer (see efm_to_regpat)
-#else
-  i += 2;   // "%f" can become two chars longer
-#endif
-  char_u *fmtstr = xmalloc(i);
+  size_t sz = efm_regpat_bufsz(efm);
+  char_u *fmtstr = xmalloc(sz);
 
   while (efm[0] != NUL) {
     // Allocate a new eformat structure and put it at the end of the list
@@ -520,13 +557,9 @@ static efm_T * parse_efm_option(char_u *efm)
     fmt_last = fmt_ptr;
 
     // Isolate one part in the 'errorformat' option
-    for (len = 0; efm[len] != NUL && efm[len] != ','; len++) {
-      if (efm[len] == '\\' && efm[len + 1] != NUL) {
-        len++;
-      }
-    }
+    len = efm_option_part_len(efm);
 
-    if (efm_to_regpat(efm, len, fmt_ptr, fmtstr, errmsg) == -1) {
+    if (efm_to_regpat(efm, len, fmt_ptr, fmtstr, errmsg) == FAIL) {
       goto parse_efm_error;
     }
     if ((fmt_ptr->prog = vim_regcomp(fmtstr, RE_MAGIC + RE_STRING)) == NULL) {
@@ -552,6 +585,9 @@ parse_efm_end:
   return fmt_first;
 }
 
+/*
+ * Allocate more memory for the line buffer used for parsing lines.
+ */
 static char_u *qf_grow_linebuf(qfstate_T *state, size_t newsz)
 {
   // If the line exceeds LINE_MAXLEN exclude the last
@@ -951,7 +987,7 @@ qf_init_ext(
   } else {
     // Adding to existing list, use last entry.
     adding = true;
-    if (qi->qf_lists[qf_idx].qf_count > 0) {
+    if (!qf_list_empty(qi, qf_idx)) {
       old_last = qi->qf_lists[qf_idx].qf_last;
     }
   }
@@ -1147,6 +1183,216 @@ static void qf_new_list(qf_info_T *qi, char_u *qf_title)
   qi->qf_lists[qi->qf_curlist].qf_id = ++last_qf_id;
 }
 
+/*
+ * Parse the match for filename ('%f') pattern in regmatch.
+ * Return the matched value in "fields->namebuf".
+ */
+static int qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields, int prefix) {
+  char_u c;
+
+  if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
+    return QF_FAIL;
+
+  /* Expand ~/file and $HOME/file to full path. */
+  c = *rmp->endp[midx];
+  *rmp->endp[midx] = NUL;
+  expand_env(rmp->startp[midx], fields->namebuf, CMDBUFFSIZE);
+  *rmp->endp[midx] = c;
+
+  /*
+   * For separate filename patterns (%O, %P and %Q), the specified file
+   * should exist.
+   */
+  if (vim_strchr((char_u *)"OPQ", prefix) != NULL
+      && !os_path_exists(fields->namebuf))
+    return QF_FAIL;
+
+  return QF_OK;
+}
+
+/*
+ * Parse the match for error number ('%n') pattern in regmatch.
+ * Return the matched value in "fields->enr".
+ */
+static int qf_parse_fmt_n(regmatch_T *rmp, int midx, qffields_T *fields) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  fields->enr = (int)atol((char *)rmp->startp[midx]);
+  return QF_OK;
+}
+
+/*
+ * Parse the match for line number (%l') pattern in regmatch.
+ * Return the matched value in "fields->lnum".
+ */
+static int qf_parse_fmt_l(regmatch_T *rmp, int midx, qffields_T *fields) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  fields->lnum = atol((char *)rmp->startp[midx]);
+  return QF_OK;
+}
+
+/*
+ * Parse the match for column number ('%c') pattern in regmatch.
+ * Return the matched value in "fields->col".
+ */
+static int qf_parse_fmt_c(regmatch_T *rmp, int midx, qffields_T *fields) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  fields->col = (int)atol((char *)rmp->startp[midx]);
+  return QF_OK;
+}
+
+/*
+ * Parse the match for error type ('%t') pattern in regmatch.
+ * Return the matched value in "fields->type".
+ */
+static int qf_parse_fmt_t(regmatch_T *rmp, int midx, qffields_T *fields) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  fields->type = *rmp->startp[midx];
+  return QF_OK;
+}
+
+/*
+ * Parse the match for '%+' format pattern. The whole matching line is included
+ * in the error string.  Return the matched line in "fields->errmsg".
+ */
+static int qf_parse_fmt_plus(char_u *linebuf, size_t linelen, qffields_T *fields) {
+  if (linelen >= fields->errmsglen) {
+    /* linelen + null terminator */
+    fields->errmsg = xrealloc(fields->errmsg, linelen + 1);
+    fields->errmsglen = linelen + 1;
+  }
+  STRLCPY(fields->errmsg, linebuf, linelen + 1);
+  return QF_OK;
+}
+
+/*
+ * Parse the match for error message ('%m') pattern in regmatch.
+ * Return the matched value in "fields->errmsg".
+ */
+static int qf_parse_fmt_m(regmatch_T *rmp, int midx, qffields_T *fields) {
+  size_t len;
+
+  if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
+    return QF_FAIL;
+  len = (size_t)(rmp->endp[midx] - rmp->startp[midx]);
+  if (len >= fields->errmsglen) {
+    /* len + null terminator */
+    fields->errmsg = xrealloc(fields->errmsg, len + 1);
+    fields->errmsglen = len + 1;
+  }
+  STRLCPY(fields->errmsg, rmp->startp[midx], len + 1);
+  return QF_OK;
+}
+
+/*
+ * Parse the match for rest of a single-line file message ('%r') pattern.
+ * Return the matched value in "tail".
+ */
+static int qf_parse_fmt_r(regmatch_T *rmp, int midx, char_u **tail) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  *tail = rmp->startp[midx];
+  return QF_OK;
+}
+
+
+/*
+ * Parse the match for the pointer line ('%p') pattern in regmatch.
+ * Return the matched value in "fields->col".
+ */
+static int qf_parse_fmt_p(regmatch_T *rmp, int midx, qffields_T *fields) {
+  char_u *match_ptr;
+
+  if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
+    return QF_FAIL;
+  fields->col = 0;
+  for (match_ptr = rmp->startp[midx]; match_ptr != rmp->endp[midx];
+      ++match_ptr)
+  {
+    ++fields->col;
+    if (*match_ptr == TAB)
+    {
+      fields->col += 7;
+      fields->col -= fields->col % 8;
+    }
+  }
+  ++fields->col;
+  fields->use_viscol = true;
+  return QF_OK;
+}
+
+
+/*
+ * Parse the match for the virtual column number ('%v') pattern in regmatch.
+ * Return the matched value in "fields->col".
+ */
+static int qf_parse_fmt_v(regmatch_T *rmp, int midx, qffields_T *fields) {
+  if (rmp->startp[midx] == NULL)
+    return QF_FAIL;
+  fields->col = (int)atol((char *)rmp->startp[midx]);
+  fields->use_viscol = true;
+  return QF_OK;
+}
+
+
+/*
+ * Parse the match for the search text ('%s') pattern in regmatch.
+ * Return the matched value in "fields->pattern".
+ */
+static int qf_parse_fmt_s(regmatch_T *rmp, int midx, qffields_T *fields) {
+  size_t len;
+
+  if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
+    return QF_FAIL;
+  len = (size_t)(rmp->endp[midx] - rmp->startp[midx]);
+  if (len > CMDBUFFSIZE - 5)
+    len = CMDBUFFSIZE - 5;
+  STRCPY(fields->pattern, "^\\V");
+  STRNCAT(fields->pattern, rmp->startp[midx], len);
+  fields->pattern[len + 3] = '\\';
+  fields->pattern[len + 4] = '$';
+  fields->pattern[len + 5] = NUL;
+  return QF_OK;
+}
+
+/*
+ * Parse the match for the module ('%o') pattern in regmatch.
+ * Return the matched value in "fields->module".
+ */
+static int qf_parse_fmt_o(regmatch_T *rmp, int midx, qffields_T *fields) {
+  size_t len;
+
+  if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
+    return QF_FAIL;
+  len = (size_t)(rmp->endp[midx] - rmp->startp[midx]);
+  if (len > CMDBUFFSIZE)
+    len = CMDBUFFSIZE;
+  STRNCAT(fields->module, rmp->startp[midx], len);
+  return QF_OK;
+}
+
+/*
+ * 'errorformat' format pattern parser functions.
+ * The '%f' and '%r' formats are parsed differently from other formats.
+ * See qf_parse_match() for details.
+ */
+static int (*qf_parse_fmt[FMT_PATTERNS])(regmatch_T *, int, qffields_T *) = {
+  NULL,
+  qf_parse_fmt_n,
+  qf_parse_fmt_l,
+  qf_parse_fmt_c,
+  qf_parse_fmt_t,
+  qf_parse_fmt_m,
+  NULL,
+  qf_parse_fmt_p,
+  qf_parse_fmt_v,
+  qf_parse_fmt_s,
+  qf_parse_fmt_o
+};
+
 /// Parse the error format matches in 'regmatch' and set the values in 'fields'.
 /// fmt_ptr contains the 'efm' format specifiers/prefixes that have a match.
 /// Returns QF_OK if all the matches are successfully parsed. On failure,
@@ -1157,7 +1403,8 @@ static int qf_parse_match(char_u *linebuf, size_t linelen, efm_T *fmt_ptr,
 {
   char_u idx = fmt_ptr->prefix;
   int i;
-  size_t len;
+  int midx;
+  int status;
 
   if ((idx == 'C' || idx == 'Z') && !qf_multiline) {
     return QF_FAIL;
@@ -1171,118 +1418,25 @@ static int qf_parse_match(char_u *linebuf, size_t linelen, efm_T *fmt_ptr,
   // Extract error message data from matched line.
   // We check for an actual submatch, because "\[" and "\]" in
   // the 'errorformat' may cause the wrong submatch to be used.
-  if ((i = (int)fmt_ptr->addr[0]) > 0) {  // %f
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL) {
-      return QF_FAIL;
+  for (i = 0; i < FMT_PATTERNS; i++) {
+    status = QF_OK;
+    midx = (int)fmt_ptr->addr[i];
+    if (i == 0 && midx > 0)				/* %f */
+      status = qf_parse_fmt_f(regmatch, midx, fields, idx);
+    else if (i == 5)
+    {
+      if (fmt_ptr->flags == '+' && !qf_multiscan)	/* %+ */
+        status = qf_parse_fmt_plus(linebuf, linelen, fields);
+      else if (midx > 0)				/* %m */
+        status = qf_parse_fmt_m(regmatch, midx, fields);
     }
+    else if (i == 6 && midx > 0)			/* %r */
+      status = qf_parse_fmt_r(regmatch, midx, tail);
+    else if (midx > 0)				/* others */
+      status = (qf_parse_fmt[i])(regmatch, midx, fields);
 
-    // Expand ~/file and $HOME/file to full path.
-    char_u c = *regmatch->endp[i];
-    *regmatch->endp[i] = NUL;
-    expand_env(regmatch->startp[i], fields->namebuf, CMDBUFFSIZE);
-    *regmatch->endp[i] = c;
-
-    if (vim_strchr((char_u *)"OPQ", idx) != NULL
-        && !os_path_exists(fields->namebuf)) {
-      return QF_FAIL;
-    }
-  }
-  if ((i = (int)fmt_ptr->addr[1]) > 0) {  // %n
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->enr = (int)atol((char *)regmatch->startp[i]);
-  }
-  if ((i = (int)fmt_ptr->addr[2]) > 0) {  // %l
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->lnum = atol((char *)regmatch->startp[i]);
-  }
-  if ((i = (int)fmt_ptr->addr[3]) > 0) {  // %c
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->col = (int)atol((char *)regmatch->startp[i]);
-  }
-  if ((i = (int)fmt_ptr->addr[4]) > 0) {  // %t
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->type = *regmatch->startp[i];
-  }
-  if (fmt_ptr->flags == '+' && !qf_multiscan) {  // %+
-    if (linelen >= fields->errmsglen) {
-      // linelen + null terminator
-      fields->errmsg = xrealloc(fields->errmsg, linelen + 1);
-      fields->errmsglen = linelen + 1;
-    }
-    STRLCPY(fields->errmsg, linebuf, linelen + 1);
-  } else if ((i = (int)fmt_ptr->addr[5]) > 0) {  // %m
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL) {
-      return QF_FAIL;
-    }
-    len = (size_t)(regmatch->endp[i] - regmatch->startp[i]);
-    if (len >= fields->errmsglen) {
-      // len + null terminator
-      fields->errmsg = xrealloc(fields->errmsg, len + 1);
-      fields->errmsglen = len + 1;
-    }
-    STRLCPY(fields->errmsg, regmatch->startp[i], len + 1);
-  }
-  if ((i = (int)fmt_ptr->addr[6]) > 0) {  // %r
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    *tail = regmatch->startp[i];
-  }
-  if ((i = (int)fmt_ptr->addr[7]) > 0) {  // %p
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->col = 0;
-    char_u *match_ptr;
-    for (match_ptr = regmatch->startp[i]; match_ptr != regmatch->endp[i];
-         match_ptr++) {
-      fields->col++;
-      if (*match_ptr == TAB) {
-        fields->col += 7;
-        fields->col -= fields->col % 8;
-      }
-    }
-    fields->col++;
-    fields->use_viscol = true;
-  }
-  if ((i = (int)fmt_ptr->addr[8]) > 0) {  // %v
-    if (regmatch->startp[i] == NULL) {
-      return QF_FAIL;
-    }
-    fields->col = (int)atol((char *)regmatch->startp[i]);
-    fields->use_viscol = true;
-  }
-  if ((i = (int)fmt_ptr->addr[9]) > 0) {  // %s
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL) {
-      return QF_FAIL;
-    }
-    len = (size_t)(regmatch->endp[i] - regmatch->startp[i]);
-    if (len > CMDBUFFSIZE - 5) {
-      len = CMDBUFFSIZE - 5;
-    }
-    STRCPY(fields->pattern, "^\\V");
-    STRNCAT(fields->pattern, regmatch->startp[i], len);
-    fields->pattern[len + 3] = '\\';
-    fields->pattern[len + 4] = '$';
-    fields->pattern[len + 5] = NUL;
-  }
-  if ((i = (int)fmt_ptr->addr[10]) > 0) {  // %o
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL) {
-      return QF_FAIL;
-    }
-    len = (size_t)(regmatch->endp[i] - regmatch->startp[i]);
-    if (len > CMDBUFFSIZE) {
-      len = CMDBUFFSIZE;
-    }
-    STRNCAT(fields->module, regmatch->startp[i], len);
+    if (status != QF_OK)
+      return status;
   }
 
   return QF_OK;
@@ -1536,7 +1690,7 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
   qfp->qf_valid = valid;
 
   lastp = &qi->qf_lists[qf_idx].qf_last;
-  if (qi->qf_lists[qf_idx].qf_count == 0) {
+  if (qf_list_empty(qi, qf_idx)) {
     // first element in the list
     qi->qf_lists[qf_idx].qf_start = qfp;
     qi->qf_lists[qf_idx].qf_ptr = qfp;
@@ -2490,7 +2644,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
     qi = &ql_info;
 
   if (qi->qf_curlist >= qi->qf_listcount
-      || qi->qf_lists[qi->qf_curlist].qf_count == 0) {
+      || qf_list_empty(qi, qi->qf_curlist)) {
     EMSG(_(e_quickfix));
     return;
   }
@@ -2597,22 +2751,102 @@ theend:
   }
 }
 
+
+/*
+ * Highlight attributes used for displaying entries from the quickfix list.
+ */
+static int	qfFileAttr;
+static int	qfSepAttr;
+static int	qfLineAttr;
+
+/*
+ * Display information about a single entry from the quickfix/location list.
+ * Used by ":clist/:llist" commands.
+ */
+static void qf_list_entry(qf_info_T *qi, qfline_T *qfp, int qf_idx) {
+  char_u	*fname;
+  buf_T	*buf;
+
+  fname = NULL;
+  if (qfp->qf_module != NULL && *qfp->qf_module != NUL)
+    vim_snprintf((char *)IObuff, IOSIZE, "%2d %s", qf_idx,
+        (char *)qfp->qf_module);
+  else {
+    if (qfp->qf_fnum != 0
+        && (buf = buflist_findnr(qfp->qf_fnum)) != NULL)
+    {
+      fname = buf->b_fname;
+      if (qfp->qf_type == 1)	/* :helpgrep */
+        fname = path_tail(fname);
+    }
+    if (fname == NULL)
+      snprintf((char *)IObuff, IOSIZE, "%2d", qf_idx);
+    else
+      vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
+          qf_idx, (char *)fname);
+  }
+
+  // Support for filtering entries using :filter /pat/ clist
+  // Match against the module name, file name, search pattern and
+  // text of the entry.
+  bool filter_entry = true;
+  if (qfp->qf_module != NULL && *qfp->qf_module != NUL)
+    filter_entry &= message_filtered(qfp->qf_module);
+  if (filter_entry && fname != NULL)
+    filter_entry &= message_filtered(fname);
+  if (filter_entry && qfp->qf_pattern != NULL)
+    filter_entry &= message_filtered(qfp->qf_pattern);
+  if (filter_entry)
+    filter_entry &= message_filtered(qfp->qf_text);
+  if (filter_entry)
+    return;
+
+  msg_putchar('\n');
+  msg_outtrans_attr(IObuff, qf_idx == qi->qf_lists[qi->qf_curlist].qf_index
+      ? HL_ATTR(HLF_QFL) : qfFileAttr);
+
+  if (qfp->qf_lnum != 0)
+    msg_puts_attr(":", qfSepAttr);
+  if (qfp->qf_lnum == 0)
+    IObuff[0] = NUL;
+  else if (qfp->qf_col == 0)
+    vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR, qfp->qf_lnum);
+  else
+    vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR " col %d",
+        qfp->qf_lnum, qfp->qf_col);
+  vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s",
+      (char *)qf_types(qfp->qf_type, qfp->qf_nr));
+  msg_puts_attr((const char *)IObuff, qfLineAttr);
+  msg_puts_attr(":", qfSepAttr);
+  if (qfp->qf_pattern != NULL)
+  {
+    qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
+    msg_puts((const char *)IObuff);
+    msg_puts_attr(":", qfSepAttr);
+  }
+  msg_puts(" ");
+
+  /* Remove newlines and leading whitespace from the text.  For an
+   * unrecognized line keep the indent, the compiler may mark a word
+   * with ^^^^. */
+  qf_fmt_text((fname != NULL || qfp->qf_lnum != 0)
+      ? skipwhite(qfp->qf_text) : qfp->qf_text,
+      IObuff, IOSIZE);
+  msg_prt_line(IObuff, FALSE);
+  ui_flush();		/* show one line at a time */
+}
+
 /*
  * ":clist": list all errors
  * ":llist": list all locations
  */
 void qf_list(exarg_T *eap)
 {
-  buf_T       *buf;
-  char_u      *fname;
   qfline_T    *qfp;
   int i;
   int idx1 = 1;
   int idx2 = -1;
   char_u      *arg = eap->arg;
-  int         qfFileAttr;
-  int         qfSepAttr;
-  int         qfLineAttr;
   int         all = eap->forceit;     // if not :cl!, only show
                                       // recognised errors
   qf_info_T   *qi = &ql_info;
@@ -2626,7 +2860,7 @@ void qf_list(exarg_T *eap)
   }
 
   if (qi->qf_curlist >= qi->qf_listcount
-      || qi->qf_lists[qi->qf_curlist].qf_count == 0) {
+      || qf_list_empty(qi, qi->qf_curlist)) {
     EMSG(_(e_quickfix));
     return;
   }
@@ -2682,80 +2916,9 @@ void qf_list(exarg_T *eap)
         break;
       }
 
-      fname = NULL;
-      if (qfp->qf_module != NULL && *qfp->qf_module != NUL) {
-        vim_snprintf((char *)IObuff, IOSIZE, "%2d %s", i,
-                     (char *)qfp->qf_module);
-      } else {
-        if (qfp->qf_fnum != 0 && (buf = buflist_findnr(qfp->qf_fnum)) != NULL) {
-          fname = buf->b_fname;
-          if (qfp->qf_type == 1) {  // :helpgrep
-            fname = path_tail(fname);
-          }
-        }
-        if (fname == NULL) {
-          snprintf((char *)IObuff, IOSIZE, "%2d", i);
-        } else {
-          vim_snprintf((char *)IObuff, IOSIZE, "%2d %s", i, (char *)fname);
-        }
-      }
-
-      // Support for filtering entries using :filter /pat/ clist
-      // Match against the module name, file name, search pattern and
-      // text of the entry.
-      bool filter_entry = true;
-      if (qfp->qf_module != NULL && *qfp->qf_module != NUL) {
-        filter_entry &= message_filtered(qfp->qf_module);
-      }
-      if (filter_entry && fname != NULL) {
-        filter_entry &= message_filtered(fname);
-      }
-      if (filter_entry && qfp->qf_pattern != NULL) {
-        filter_entry &= message_filtered(qfp->qf_pattern);
-      }
-      if (filter_entry) {
-        filter_entry &= message_filtered(qfp->qf_text);
-      }
-      if (filter_entry) {
-        goto next_entry;
-      }
-      msg_putchar('\n');
-      msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-                        ? HL_ATTR(HLF_QFL) : qfFileAttr);
-
-      if (qfp->qf_lnum != 0) {
-        msg_puts_attr(":", qfSepAttr);
-      }
-      if (qfp->qf_lnum == 0) {
-        IObuff[0] = NUL;
-      } else if (qfp->qf_col == 0) {
-        vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR, qfp->qf_lnum);
-      } else {
-        vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR " col %d",
-                     qfp->qf_lnum, qfp->qf_col);
-      }
-      vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s",
-                   (char *)qf_types(qfp->qf_type, qfp->qf_nr));
-      msg_puts_attr((const char *)IObuff, qfLineAttr);
-      msg_puts_attr(":", qfSepAttr);
-      if (qfp->qf_pattern != NULL) {
-        qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
-        msg_puts((const char *)IObuff);
-        msg_puts_attr(":", qfSepAttr);
-      }
-      msg_puts(" ");
-
-      /* Remove newlines and leading whitespace from the text.  For an
-       * unrecognized line keep the indent, the compiler may mark a word
-       * with ^^^^. */
-      qf_fmt_text((fname != NULL || qfp->qf_lnum != 0)
-          ? skipwhite(qfp->qf_text) : qfp->qf_text,
-          IObuff, IOSIZE);
-      msg_prt_line(IObuff, FALSE);
-      ui_flush();                      /* show one line at a time */
+      qf_list_entry(qi, qfp, i);
     }
 
-next_entry:
     qfp = qfp->qf_next;
     if (qfp == NULL) {
       break;
@@ -2867,7 +3030,7 @@ void qf_history(exarg_T *eap)
     qi = GET_LOC_LIST(curwin);
   }
   if (qi == NULL || (qi->qf_listcount == 0
-                     && qi->qf_lists[qi->qf_curlist].qf_count == 0)) {
+                     && qf_list_empty(qi, qi->qf_curlist))) {
     MSG(_("No entries"));
   } else {
     for (i = 0; i < qi->qf_listcount; i++) {
@@ -2960,7 +3123,7 @@ bool qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount,
   }
 
   for (idx = 0; idx < qi->qf_listcount; ++idx)
-    if (qi->qf_lists[idx].qf_count)
+    if (!qf_list_empty(qi, idx))
       for (i = 0, qfp = qi->qf_lists[idx].qf_start;
            i < qi->qf_lists[idx].qf_count && qfp != NULL;
            i++, qfp = qfp->qf_next) {
@@ -3080,7 +3243,7 @@ void ex_cwindow(exarg_T *eap)
    * it if we have errors; otherwise, leave it closed.
    */
   if (qi->qf_lists[qi->qf_curlist].qf_nonevalid
-      || qi->qf_lists[qi->qf_curlist].qf_count == 0
+      || qf_list_empty(qi, qi->qf_curlist)
       || qi->qf_curlist >= qi->qf_listcount) {
     if (win != NULL)
       ex_cclose(eap);
@@ -4478,7 +4641,7 @@ void ex_vimgrep(exarg_T *eap)
   }
 
   /* Jump to first match. */
-  if (qi->qf_lists[qi->qf_curlist].qf_count > 0) {
+  if (!qf_list_empty(qi, qi->qf_curlist)) {
     if ((flags & VGR_NOJUMP) == 0) {
       vgr_jump_to_match(qi, eap->forceit, &redraw_for_dummy, first_match_buf,
                         target_dir);
@@ -4687,7 +4850,7 @@ int get_errorlist(const qf_info_T *qi_arg, win_T *wp, int qf_idx, list_T *list)
   }
 
   if (qf_idx >= qi->qf_listcount
-      || qi->qf_lists[qf_idx].qf_count == 0) {
+      || qf_list_empty(qi, qf_idx)) {
     return FAIL;
   }
 
@@ -4970,7 +5133,7 @@ static int qf_getprop_ctx(qf_info_T *qi, int qf_idx, dict_T *retdict)
 static int qf_getprop_idx(qf_info_T *qi, int qf_idx, dict_T *retdict)
 {
   int idx = qi->qf_lists[qf_idx].qf_index;
-  if (qi->qf_lists[qf_idx].qf_count == 0) {
+  if (qf_list_empty(qi, qf_idx)) {
     // For empty lists, qf_index is set to 1
     idx = 0;
   }
@@ -5053,7 +5216,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
     // make place for a new list
     qf_new_list(qi, title);
     qf_idx = qi->qf_curlist;
-  } else if (action == 'a' && qi->qf_lists[qf_idx].qf_count > 0) {
+  } else if (action == 'a' && !qf_list_empty(qi, qf_idx)) {
     // Adding to existing list, use last entry.
     old_last = qi->qf_lists[qf_idx].qf_last;
   } else if (action == 'r') {
@@ -5140,7 +5303,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
   }
   if (action != 'a') {
     qi->qf_lists[qf_idx].qf_ptr = qi->qf_lists[qf_idx].qf_start;
-    if (qi->qf_lists[qf_idx].qf_count > 0) {
+    if (!qf_list_empty(qi, qf_idx)) {
       qi->qf_lists[qf_idx].qf_index = 1;
     }
   }
@@ -5862,7 +6025,7 @@ void ex_helpgrep(exarg_T *eap)
   }
 
   /* Jump to first match. */
-  if (qi->qf_lists[qi->qf_curlist].qf_count > 0)
+  if (!qf_list_empty(qi, qi->qf_curlist))
     qf_jump(qi, 0, 0, FALSE);
   else
     EMSG2(_(e_nomatch2), eap->arg);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2851,7 +2851,7 @@ void qf_list(exarg_T *eap)
                                       // recognised errors
   qf_info_T   *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_llist) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -2987,7 +2987,7 @@ void qf_age(exarg_T *eap)
   qf_info_T   *qi = &ql_info;
   int count;
 
-  if (eap->cmdidx == CMD_lolder || eap->cmdidx == CMD_lnewer) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -3026,7 +3026,7 @@ void qf_history(exarg_T *eap)
   qf_info_T *qi = &ql_info;
   int i;
 
-  if (eap->cmdidx == CMD_lhistory) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
   }
   if (qi == NULL || (qi->qf_listcount == 0
@@ -3228,7 +3228,7 @@ void ex_cwindow(exarg_T *eap)
   qf_info_T   *qi = &ql_info;
   win_T       *win;
 
-  if (eap->cmdidx == CMD_lwindow) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL)
       return;
@@ -3260,7 +3260,7 @@ void ex_cclose(exarg_T *eap)
   win_T       *win = NULL;
   qf_info_T   *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_lclose || eap->cmdidx == CMD_lwindow) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL)
       return;
@@ -3286,7 +3286,7 @@ void ex_copen(exarg_T *eap)
   buf_T       *qf_buf;
   win_T       *oldwin = curwin;
 
-  if (eap->cmdidx == CMD_lopen || eap->cmdidx == CMD_lwindow) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -3343,7 +3343,7 @@ void ex_copen(exarg_T *eap)
     }
     RESET_BINDING(curwin);
 
-    if (eap->cmdidx == CMD_lopen || eap->cmdidx == CMD_lwindow) {
+    if (is_loclist_cmd(eap->cmdidx)) {
       /*
        * For the location list window, create a reference to the
        * location list from the window 'win'.
@@ -3415,7 +3415,7 @@ void ex_cbottom(exarg_T *eap)
 {
   qf_info_T *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_lbottom) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -3817,8 +3817,7 @@ void ex_make(exarg_T *eap)
     }
   }
 
-  if (eap->cmdidx == CMD_lmake || eap->cmdidx == CMD_lgrep
-      || eap->cmdidx == CMD_lgrepadd)
+  if (is_loclist_cmd(eap->cmdidx))
     wp = curwin;
 
   autowrite_all();
@@ -3934,7 +3933,7 @@ size_t qf_get_size(exarg_T *eap)
   FUNC_ATTR_NONNULL_ALL
 {
   qf_info_T *qi = &ql_info;
-  if (eap->cmdidx == CMD_ldo || eap->cmdidx == CMD_lfdo) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     // Location list.
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
@@ -3974,7 +3973,7 @@ size_t qf_get_cur_idx(exarg_T *eap)
 {
   qf_info_T *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_ldo || eap->cmdidx == CMD_lfdo) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     // Location list.
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
@@ -3994,7 +3993,7 @@ int qf_get_cur_valid_idx(exarg_T *eap)
 {
   qf_info_T *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_ldo || eap->cmdidx == CMD_lfdo) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     // Location list.
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
@@ -4087,12 +4086,7 @@ void ex_cc(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
 
-  if (eap->cmdidx == CMD_ll
-      || eap->cmdidx == CMD_lrewind
-      || eap->cmdidx == CMD_lfirst
-      || eap->cmdidx == CMD_llast
-      || eap->cmdidx == CMD_ldo
-      || eap->cmdidx == CMD_lfdo) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -4103,13 +4097,18 @@ void ex_cc(exarg_T *eap)
   int errornr;
   if (eap->addr_count > 0) {
     errornr = (int)eap->line2;
-  } else if (eap->cmdidx == CMD_cc || eap->cmdidx == CMD_ll) {
-    errornr = 0;
-  } else if (eap->cmdidx == CMD_crewind || eap->cmdidx == CMD_lrewind
-           || eap->cmdidx == CMD_cfirst || eap->cmdidx == CMD_lfirst) {
-    errornr = 1;
   } else {
-    errornr = 32767;
+    switch (eap->cmdidx) {
+      case CMD_cc: case CMD_ll:
+        errornr = 0;
+        break;
+      case CMD_crewind: case CMD_lrewind: case CMD_cfirst:
+      case CMD_lfirst:
+        errornr = 1;
+        break;
+      default:
+        errornr = 32767;
+    }
   }
 
   // For cdo and ldo commands, jump to the nth valid error.
@@ -4140,15 +4139,9 @@ void ex_cc(exarg_T *eap)
 void ex_cnext(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
+  int dir;
 
-  if (eap->cmdidx == CMD_lnext
-      || eap->cmdidx == CMD_lNext
-      || eap->cmdidx == CMD_lprevious
-      || eap->cmdidx == CMD_lnfile
-      || eap->cmdidx == CMD_lNfile
-      || eap->cmdidx == CMD_lpfile
-      || eap->cmdidx == CMD_ldo
-      || eap->cmdidx == CMD_lfdo) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
     if (qi == NULL) {
       EMSG(_(e_loclist));
@@ -4165,17 +4158,27 @@ void ex_cnext(exarg_T *eap)
     errornr = 1;
   }
 
-  qf_jump(qi, (eap->cmdidx == CMD_cnext || eap->cmdidx == CMD_lnext
-               || eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo)
-      ? FORWARD
-      : (eap->cmdidx == CMD_cnfile || eap->cmdidx == CMD_lnfile
-        || eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo)
-      ? FORWARD_FILE
-      : (eap->cmdidx == CMD_cpfile || eap->cmdidx == CMD_lpfile
-         || eap->cmdidx == CMD_cNfile || eap->cmdidx == CMD_lNfile)
-      ? BACKWARD_FILE
-      : BACKWARD,
-      errornr, eap->forceit);
+  // Depending on the command jump to either next or previous entry/file.
+  switch (eap->cmdidx) {
+    case CMD_cnext: case CMD_lnext: case CMD_cdo: case CMD_ldo:
+      dir = FORWARD;
+      break;
+    case CMD_cprevious: case CMD_lprevious: case CMD_cNext:
+    case CMD_lNext:
+      dir = BACKWARD;
+      break;
+    case CMD_cnfile: case CMD_lnfile: case CMD_cfdo: case CMD_lfdo:
+      dir = FORWARD_FILE;
+      break;
+    case CMD_cpfile: case CMD_lpfile: case CMD_cNfile: case CMD_lNfile:
+      dir = BACKWARD_FILE;
+      break;
+    default:
+      dir = FORWARD;
+      break;
+  }
+
+  qf_jump(qi, dir, errornr, eap->forceit);
 }
 
 /*
@@ -4204,9 +4207,7 @@ void ex_cfile(exarg_T *eap)
 
   char_u *enc = (*curbuf->b_p_menc != NUL) ? curbuf->b_p_menc : p_menc;
 
-  if (eap->cmdidx == CMD_lfile
-      || eap->cmdidx == CMD_lgetfile
-      || eap->cmdidx == CMD_laddfile) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     wp = curwin;
   }
 
@@ -4463,10 +4464,7 @@ void ex_vimgrep(exarg_T *eap)
     }
   }
 
-  if (eap->cmdidx == CMD_lgrep
-      || eap->cmdidx == CMD_lvimgrep
-      || eap->cmdidx == CMD_lgrepadd
-      || eap->cmdidx == CMD_lvimgrepadd) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = ll_get_or_alloc_list(curwin);
     wp = curwin;
   }
@@ -5676,9 +5674,7 @@ void ex_cbuffer(exarg_T *eap)
   }
 
   // Must come after autocommands.
-  if (eap->cmdidx == CMD_lbuffer
-      || eap->cmdidx == CMD_lgetbuffer
-      || eap->cmdidx == CMD_laddbuffer) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     qi = ll_get_or_alloc_list(curwin);
     wp = curwin;
   }
@@ -5778,9 +5774,7 @@ void ex_cexpr(exarg_T *eap)
     }
   }
 
-  if (eap->cmdidx == CMD_lexpr
-      || eap->cmdidx == CMD_lgetexpr
-      || eap->cmdidx == CMD_laddexpr) {
+   if (is_loclist_cmd(eap->cmdidx)) {
     qi = ll_get_or_alloc_list(curwin);
     wp = curwin;
   }
@@ -5981,7 +5975,7 @@ void ex_helpgrep(exarg_T *eap)
   char_u *const save_cpo = p_cpo;
   p_cpo = empty_option;
 
-  if (eap->cmdidx == CMD_lhelpgrep) {
+  if (is_loclist_cmd(eap->cmdidx) ) {
     qi = hgr_get_ll(&new_qi);
     if (qi == NULL) {
       return;
@@ -6030,7 +6024,7 @@ void ex_helpgrep(exarg_T *eap)
   else
     EMSG2(_(e_nomatch2), eap->arg);
 
-  if (eap->cmdidx == CMD_lhelpgrep) {
+  if (is_loclist_cmd(eap->cmdidx)) {
     /* If the help window is not opened or if it already points to the
      * correct location list, then free the new location list. */
     if (!bt_help(curwin->w_buffer) || curwin->w_llist == qi) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -229,6 +229,12 @@ typedef struct {
 //
 #define GET_LOC_LIST(wp) (IS_LL_WINDOW(wp) ? wp->w_llist_ref : wp->w_llist)
 
+#define FOR_ALL_QFL_ITEMS(qfl, qfp, i) \
+  for (i = 0, qfp = qfl->qf_start; \
+      !got_int && i < qfl->qf_count && qfp != NULL; \
+      ++i, qfp = qfp->qf_next)
+
+
 // Looking up a buffer can be slow if there are many.  Remember the last one
 // to make this a lot faster if there are multiple matches in the same file.
 static char_u *qf_last_bufname = NULL;
@@ -1780,9 +1786,7 @@ static int copy_loclist_entries(qf_list_T *from_qfl, qf_list_T *to_qfl) {
   qfline_T    *prevp;
 
   // copy all the location entries in this list
-  for (i = 0, from_qfp = from_qfl->qf_start;
-      i < from_qfl->qf_count && from_qfp != NULL;
-      ++i, from_qfp = from_qfp->qf_next)
+  FOR_ALL_QFL_ITEMS(from_qfl, from_qfp, i)
   {
     if (qf_add_entry(to_qfl,
           NULL,
@@ -2134,8 +2138,8 @@ static bool is_qf_entry_present(qf_list_T *qfl, qfline_T *qf_ptr)
   int i;
 
   // Search for the entry in the current list
-  for (i = 0, qfp = qfl->qf_start; i < qfl->qf_count; i++, qfp = qfp->qf_next) {
-    if (qfp == NULL || qfp == qf_ptr) {
+  FOR_ALL_QFL_ITEMS(qfl, qfp, i) {
+    if (qfp == qf_ptr) {
       break;
     }
   }
@@ -3166,11 +3170,8 @@ bool qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount,
 
   for (idx = 0; idx < qi->qf_listcount; ++idx) {
     qf_list_T	*qfl = qf_get_list(qi, idx);
-
     if (!qf_list_empty(qfl)) {
-      for (i = 0, qfp = qfl->qf_start;
-        i < qfl->qf_count && qfp != NULL;
-           i++, qfp = qfp->qf_next) {
+      FOR_ALL_QFL_ITEMS(qfl, qfp, i) {
         if (qfp->qf_fnum == curbuf->b_fnum) {
           found_one = true;
           if (qfp->qf_lnum >= line1 && qfp->qf_lnum <= line2) {
@@ -3998,8 +3999,7 @@ size_t qf_get_size(exarg_T *eap)
   size_t i;
   assert(qf_get_curlist(qi)->qf_count >= 0);
   qfl = qf_get_curlist(qi);
-  for (i = 0, qfp = qfl->qf_start; i < (size_t)qfl->qf_count && qfp != NULL;
-       i++, qfp = qfp->qf_next) {
+  FOR_ALL_QFL_ITEMS(qfl, qfp, i) {
     if (!qfp->qf_valid) {
       continue;
     }
@@ -4231,6 +4231,25 @@ void ex_cnext(exarg_T *eap)
 }
 
 /*
+ * Return the autocmd name for the :cfile Ex commands
+ */
+  static char_u *
+cfile_get_auname(cmdidx_T cmdidx)
+{
+  switch (cmdidx)
+  {
+    case CMD_cfile:    return (char_u *)"cfile";
+    case CMD_cgetfile: return (char_u *)"cgetfile";
+    case CMD_caddfile: return (char_u *)"caddfile";
+    case CMD_lfile:    return (char_u *)"lfile";
+    case CMD_lgetfile: return (char_u *)"lgetfile";
+    case CMD_laddfile: return (char_u *)"laddfile";
+    default:           return NULL;
+  }
+}
+
+
+/*
  * ":cfile"/":cgetfile"/":caddfile" commands.
  * ":lfile"/":lgetfile"/":laddfile" commands.
  */
@@ -4240,17 +4259,10 @@ void ex_cfile(exarg_T *eap)
   qf_info_T   *qi = &ql_info;
   char_u      *au_name = NULL;
 
-  switch (eap->cmdidx) {
-  case CMD_cfile:     au_name = (char_u *)"cfile"; break;
-  case CMD_cgetfile:  au_name = (char_u *)"cgetfile"; break;
-  case CMD_caddfile:  au_name = (char_u *)"caddfile"; break;
-  case CMD_lfile:     au_name = (char_u *)"lfile"; break;
-  case CMD_lgetfile:  au_name = (char_u *)"lgetfile"; break;
-  case CMD_laddfile:  au_name = (char_u *)"laddfile"; break;
-  default: break;
-  }
+  au_name = cfile_get_auname(eap->cmdidx);
   if (au_name != NULL)
     apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name, NULL, FALSE, curbuf);
+
   if (*eap->arg != NUL)
     set_string_option_direct((char_u *)"ef", -1, eap->arg, OPT_FREE, 0);
 
@@ -4873,16 +4885,59 @@ static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
   }
 }
 
+/*
+ * Copy the specified quickfix entry items into a new dict and appened the dict
+ * to 'list'.  Returns OK on success.
+ */
+static int get_qfline_items(qfline_T *qfp, list_T *list) {
+  char_u buf[2];
+  int bufnum;
+
+  // Handle entries with a non-existing buffer number.
+  bufnum = qfp->qf_fnum;
+  if (bufnum != 0 && (buflist_findnr(bufnum) == NULL))
+    bufnum = 0;
+
+  dict_T *const dict = tv_dict_alloc();
+  tv_list_append_dict(list, dict);
+
+  buf[0] = qfp->qf_type;
+  buf[1] = NUL;
+  if (tv_dict_add_nr(dict, S_LEN("bufnr"), (varnumber_T)bufnum) == FAIL
+      || (tv_dict_add_nr(dict, S_LEN("lnum"), (varnumber_T)qfp->qf_lnum) == FAIL)
+      || (tv_dict_add_nr(dict, S_LEN("col"), (varnumber_T)qfp->qf_col) == FAIL)
+      || (tv_dict_add_nr(dict, S_LEN("vcol"), (varnumber_T)qfp->qf_viscol) == FAIL)
+      || (tv_dict_add_nr(dict, S_LEN("nr"), (varnumber_T)qfp->qf_nr) == FAIL)
+      || tv_dict_add_str(dict, S_LEN("module"),
+        (qfp->qf_module == NULL
+         ? ""
+         : (const char *)qfp->qf_module)) == FAIL
+      || tv_dict_add_str(dict, S_LEN("pattern"),
+        (qfp->qf_pattern == NULL
+         ? ""
+         : (const char *)qfp->qf_pattern)) == FAIL
+      || tv_dict_add_str(dict, S_LEN("text"),
+        (qfp->qf_text == NULL
+         ? ""
+         : (const char *)qfp->qf_text)) == FAIL
+      || tv_dict_add_str(dict, S_LEN("type"), (const char *)buf) == FAIL
+      || (tv_dict_add_nr(dict, S_LEN("valid"), (varnumber_T)qfp->qf_valid) == FAIL)) {
+    // tv_dict_add* fail only if key already exist, but this is a newly
+    // allocated dictionary which is thus guaranteed to have no existing keys.
+    assert(false);
+  }
+
+  return OK;
+}
+
 /// Add each quickfix error to list "list" as a dictionary.
 /// If qf_idx is -1, use the current list. Otherwise, use the specified list.
 int get_errorlist(const qf_info_T *qi_arg, win_T *wp, int qf_idx, list_T *list)
 {
   const qf_info_T *qi = qi_arg;
   qf_list_T *qfl;
-  char_u buf[2];
   qfline_T    *qfp;
   int i;
-  int bufnum;
 
   if (qi == NULL) {
     qi = &ql_info;
@@ -4907,51 +4962,10 @@ int get_errorlist(const qf_info_T *qi_arg, win_T *wp, int qf_idx, list_T *list)
     return FAIL;
   }
 
-  qfp = qfl->qf_start;
-  for (i = 1; !got_int && i <= qfl->qf_count; ++i) {
-    // Handle entries with a non-existing buffer number.
-    bufnum = qfp->qf_fnum;
-    if (bufnum != 0 && (buflist_findnr(bufnum) == NULL))
-      bufnum = 0;
-
-    dict_T *const dict = tv_dict_alloc();
-    tv_list_append_dict(list, dict);
-
-    buf[0] = qfp->qf_type;
-    buf[1] = NUL;
-    if (tv_dict_add_nr(dict, S_LEN("bufnr"), (varnumber_T)bufnum) == FAIL
-        || (tv_dict_add_nr(dict, S_LEN("lnum"), (varnumber_T)qfp->qf_lnum)
-            == FAIL)
-        || (tv_dict_add_nr(dict, S_LEN("col"), (varnumber_T)qfp->qf_col)
-            == FAIL)
-        || (tv_dict_add_nr(dict, S_LEN("vcol"), (varnumber_T)qfp->qf_viscol)
-            == FAIL)
-        || (tv_dict_add_nr(dict, S_LEN("nr"), (varnumber_T)qfp->qf_nr) == FAIL)
-        || tv_dict_add_str(dict, S_LEN("module"),
-                           (qfp->qf_module == NULL
-                            ? ""
-                            : (const char *)qfp->qf_module)) == FAIL
-        || tv_dict_add_str(dict, S_LEN("pattern"),
-                           (qfp->qf_pattern == NULL
-                            ? ""
-                            : (const char *)qfp->qf_pattern)) == FAIL
-        || tv_dict_add_str(dict, S_LEN("text"),
-                           (qfp->qf_text == NULL
-                            ? ""
-                            : (const char *)qfp->qf_text)) == FAIL
-        || tv_dict_add_str(dict, S_LEN("type"), (const char *)buf) == FAIL
-        || (tv_dict_add_nr(dict, S_LEN("valid"), (varnumber_T)qfp->qf_valid)
-            == FAIL)) {
-      // tv_dict_add* fail only if key already exist, but this is a newly
-      // allocated dictionary which is thus guaranteed to have no existing keys.
-      assert(false);
-    }
-
-    qfp = qfp->qf_next;
-    if (qfp == NULL) {
-      break;
-    }
+  FOR_ALL_QFL_ITEMS(qfl, qfp, i) {
+    get_qfline_items(qfp, list);
   }
+
   return OK;
 }
 
@@ -5740,6 +5754,73 @@ bool set_ref_in_quickfix(int copyID)
 }
 
 /*
+ * Return the autocmd name for the :cbuffer Ex commands
+ */
+  static const char_u *
+cbuffer_get_auname(cmdidx_T cmdidx)
+{
+  switch (cmdidx)
+  {
+    case CMD_cbuffer:    return "cbuffer";
+    case CMD_cgetbuffer: return "cgetbuffer";
+    case CMD_caddbuffer: return "caddbuffer";
+    case CMD_lbuffer:    return "lbuffer";
+    case CMD_lgetbuffer: return "lgetbuffer";
+    case CMD_laddbuffer: return "laddbuffer";
+    default:             return NULL;
+  }
+}
+
+/*
+ * Process and validate the arguments passed to the :cbuffer, :caddbuffer,
+ * :cgetbuffer, :lbuffer, :laddbuffer, :lgetbuffer Ex commands.
+ */
+static int cbuffer_process_args(
+    exarg_T		*eap,
+    buf_T		**bufp,
+    linenr_T	*line1,
+    linenr_T	*line2)
+{
+  buf_T	*buf = NULL;
+
+  if (*eap->arg == NUL)
+    buf = curbuf;
+  else if (*skipwhite(skipdigits(eap->arg)) == NUL)
+    buf = buflist_findnr(atoi((char *)eap->arg));
+
+  if (buf == NULL)
+  {
+    emsg(_(e_invarg));
+    return FAIL;
+  }
+
+  if (buf->b_ml.ml_mfp == NULL)
+  {
+    emsg(_("E681: Buffer is not loaded"));
+    return FAIL;
+  }
+
+  if (eap->addr_count == 0)
+  {
+    eap->line1 = 1;
+    eap->line2 = buf->b_ml.ml_line_count;
+  }
+
+  if (eap->line1 < 1 || eap->line1 > buf->b_ml.ml_line_count
+      || eap->line2 < 1 || eap->line2 > buf->b_ml.ml_line_count)
+  {
+    emsg(_(e_invrange));
+    return FAIL;
+  }
+
+  *line1 = eap->line1;
+  *line2 = eap->line2;
+  *bufp = buf;
+
+  return OK;
+}
+
+/*
  * ":[range]cbuffer [bufnr]" command.
  * ":[range]caddbuffer [bufnr]" command.
  * ":[range]cgetbuffer [bufnr]" command.
@@ -5753,30 +5834,11 @@ void ex_cbuffer(exarg_T *eap)
   qf_info_T *qi = &ql_info;
   const char *au_name = NULL;
   win_T *wp = NULL;
+  char_u* qf_title;
+  linenr_T line1;
+  linenr_T line2;
 
-  switch (eap->cmdidx) {
-    case CMD_cbuffer:
-      au_name = "cbuffer";
-      break;
-    case CMD_cgetbuffer:
-      au_name = "cgetbuffer";
-      break;
-    case CMD_caddbuffer:
-      au_name = "caddbuffer";
-      break;
-    case CMD_lbuffer:
-      au_name = "lbuffer";
-      break;
-    case CMD_lgetbuffer:
-      au_name = "lgetbuffer";
-      break;
-    case CMD_laddbuffer:
-      au_name = "laddbuffer";
-      break;
-    default:
-      break;
-  }
-
+  au_name = cbuffer_get_auname(eap->cmdidx);
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
                                         curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
@@ -5790,59 +5852,60 @@ void ex_cbuffer(exarg_T *eap)
     wp = curwin;
   }
 
-  if (*eap->arg == NUL)
-    buf = curbuf;
-  else if (*skipwhite(skipdigits(eap->arg)) == NUL)
-    buf = buflist_findnr(atoi((char *)eap->arg));
-  if (buf == NULL)
-    EMSG(_(e_invarg));
-  else if (buf->b_ml.ml_mfp == NULL)
-    EMSG(_("E681: Buffer is not loaded"));
-  else {
-    if (eap->addr_count == 0) {
-      eap->line1 = 1;
-      eap->line2 = buf->b_ml.ml_line_count;
-    }
-    if (eap->line1 < 1 || eap->line1 > buf->b_ml.ml_line_count
-        || eap->line2 < 1 || eap->line2 > buf->b_ml.ml_line_count) {
-      EMSG(_(e_invrange));
-    } else {
-      char_u *qf_title = qf_cmdtitle(*eap->cmdlinep);
+  if (cbuffer_process_args(eap, &buf, &line1, &line2) == FAIL)
+    return;
 
-      if (buf->b_sfname) {
-        vim_snprintf((char *)IObuff, IOSIZE, "%s (%s)",
-            (char *)qf_title, (char *)buf->b_sfname);
-        qf_title = IObuff;
-      }
+  qf_title = qf_cmdtitle(*eap->cmdlinep);
 
-      int res = qf_init_ext(qi, qi->qf_curlist, NULL, buf, NULL, p_efm,
-                            (eap->cmdidx != CMD_caddbuffer
-                             && eap->cmdidx != CMD_laddbuffer),
-                            eap->line1, eap->line2, qf_title, NULL);
-      if (res >= 0) {
-        qf_list_changed(qf_get_curlist(qi));
-      }
-      // Remember the current quickfix list identifier, so that we can
-      // check for autocommands changing the current quickfix list.
-      unsigned save_qfid = qf_get_curlist(qi)->qf_id;
-      if (au_name != NULL) {
-        const buf_T *const curbuf_old = curbuf;
-        apply_autocmds(EVENT_QUICKFIXCMDPOST, (char_u *)au_name,
-                       curbuf->b_fname, true, curbuf);
-        if (curbuf != curbuf_old) {
-          // Autocommands changed buffer, don't jump now, "qi" may
-          // be invalid.
-          res = 0;
-        }
-      }
-      // Jump to the first error for new list and if autocmds didn't
-      // free the list.
-      if (res > 0 && (eap->cmdidx == CMD_cbuffer || eap->cmdidx == CMD_lbuffer)
-          && qflist_valid(wp, save_qfid)) {
-        // display the first error
-        qf_jump_first(qi, save_qfid, eap->forceit);
-      }
+  if (buf->b_sfname) {
+    vim_snprintf((char *)IObuff, IOSIZE, "%s (%s)",
+        (char *)qf_title, (char *)buf->b_sfname);
+    qf_title = IObuff;
+  }
+
+  int res = qf_init_ext(qi, qi->qf_curlist, NULL, buf, NULL, p_efm,
+      (eap->cmdidx != CMD_caddbuffer
+       && eap->cmdidx != CMD_laddbuffer),
+      eap->line1, eap->line2, qf_title, NULL);
+  if (res >= 0) {
+    qf_list_changed(qf_get_curlist(qi));
+  }
+  // Remember the current quickfix list identifier, so that we can
+  // check for autocommands changing the current quickfix list.
+  unsigned save_qfid = qf_get_curlist(qi)->qf_id;
+  if (au_name != NULL) {
+    const buf_T *const curbuf_old = curbuf;
+    apply_autocmds(EVENT_QUICKFIXCMDPOST, (char_u *)au_name,
+        curbuf->b_fname, true, curbuf);
+    if (curbuf != curbuf_old) {
+      // Autocommands changed buffer, don't jump now, "qi" may
+      // be invalid.
+      res = 0;
     }
+  }
+  // Jump to the first error for new list and if autocmds didn't
+  // free the list.
+  if (res > 0 && (eap->cmdidx == CMD_cbuffer || eap->cmdidx == CMD_lbuffer)
+      && qflist_valid(wp, save_qfid)) {
+    // display the first error
+    qf_jump_first(qi, save_qfid, eap->forceit);
+  }
+}
+
+/*
+ * Return the autocmd name for the :cexpr Ex commands.
+ */
+static const char_u * cexpr_get_auname(cmdidx_T cmdidx)
+{
+  switch (cmdidx)
+  {
+    case CMD_cexpr:    return "cexpr";
+    case CMD_cgetexpr: return "cgetexpr";
+    case CMD_caddexpr: return "caddexpr";
+    case CMD_lexpr:    return "lexpr";
+    case CMD_lgetexpr: return "lgetexpr";
+    case CMD_laddexpr: return "laddexpr";
+    default:           return NULL;
   }
 }
 
@@ -5856,28 +5919,7 @@ void ex_cexpr(exarg_T *eap)
   const char *au_name = NULL;
   win_T *wp = NULL;
 
-  switch (eap->cmdidx) {
-    case CMD_cexpr:
-      au_name = "cexpr";
-      break;
-    case CMD_cgetexpr:
-      au_name = "cgetexpr";
-      break;
-    case CMD_caddexpr:
-      au_name = "caddexpr";
-      break;
-    case CMD_lexpr:
-      au_name = "lexpr";
-      break;
-    case CMD_lgetexpr:
-      au_name = "lgetexpr";
-      break;
-    case CMD_laddexpr:
-      au_name = "laddexpr";
-      break;
-    default:
-      break;
-  }
+  au_name = cexpr_get_auname(eap->cmdidx);
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
                                         curbuf->b_fname, true, curbuf)) {
     if (aborting()) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5200,6 +5200,81 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   return status;
 }
 
+
+/*
+ * Add a new quickfix entry to list at 'qf_idx' in the stack 'qi' from the
+ * items in the dict 'd'.
+ */
+static int qf_add_entry_from_dict(
+    qf_info_T *qi,
+    int qf_idx,
+    dict_T *d,
+    int first_entry)
+{
+  bool did_bufnr_emsg;
+
+  if (first_entry)
+    did_bufnr_emsg = false;
+
+  char *const filename = tv_dict_get_string(d, "filename", true);
+  char *const module = tv_dict_get_string(d, "module", true);
+  int bufnum = (int)tv_dict_get_number(d, "bufnr");
+  long lnum = (long)tv_dict_get_number(d, "lnum");
+  int col = (int)tv_dict_get_number(d, "col");
+  char_u vcol = (char_u)tv_dict_get_number(d, "vcol");
+  int nr = (int)tv_dict_get_number(d, "nr");
+  const char *type_str = tv_dict_get_string(d, "type", false);
+  const char_u type = (char_u)(uint8_t)(type_str == NULL ? NUL : *type_str);
+  char *const pattern = tv_dict_get_string(d, "pattern", true);
+  char *text = tv_dict_get_string(d, "text", true);
+  if (text == NULL) {
+    text = xcalloc(1, 1);
+  }
+
+  bool valid = true;
+  if ((filename == NULL && bufnum == 0) || (lnum == 0 && pattern == NULL)) {
+    valid = false;
+  }
+
+  /* Mark entries with non-existing buffer number as not valid. Give the
+   * error message only once. */
+  if (bufnum != 0 && (buflist_findnr(bufnum) == NULL)) {
+    if (!did_bufnr_emsg) {
+      did_bufnr_emsg = true;
+      EMSGN(_("E92: Buffer %" PRId64 " not found"), bufnum);
+    }
+    valid = false;
+    bufnum = 0;
+  }
+
+  // If the 'valid' field is present it overrules the detected value.
+  if (tv_dict_find(d, "valid", -1) != NULL) {
+    valid = (int)tv_dict_get_number(d, "valid");
+  }
+
+  int status = qf_add_entry(qi,
+      qf_idx,
+      NULL,      // dir
+      (char_u *)filename,
+      (char_u *)module,
+      bufnum,
+      (char_u *)text,
+      lnum,
+      col,
+      vcol,      // vis_col
+      (char_u *)pattern,   // search pattern
+      nr,
+      type,
+      valid);
+
+  xfree(filename);
+  xfree(module);
+  xfree(pattern);
+  xfree(text);
+
+  return status;
+}
+
 /// Add list of entries to quickfix/location list. Each list entry is
 /// a dictionary with item information.
 static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
@@ -5208,7 +5283,6 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
   dict_T *d;
   qfline_T *old_last = NULL;
   int retval = OK;
-  bool did_bufnr_emsg = false;
 
   if (action == ' ' || qf_idx == qi->qf_listcount) {
     // make place for a new list
@@ -5232,63 +5306,8 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
       continue;
     }
 
-    char *const filename = tv_dict_get_string(d, "filename", true);
-    char *const module = tv_dict_get_string(d, "module", true);
-    int bufnum = (int)tv_dict_get_number(d, "bufnr");
-    long lnum = (long)tv_dict_get_number(d, "lnum");
-    int col = (int)tv_dict_get_number(d, "col");
-    char_u vcol = (char_u)tv_dict_get_number(d, "vcol");
-    int nr = (int)tv_dict_get_number(d, "nr");
-    const char *type_str = tv_dict_get_string(d, "type", false);
-    const char_u type = (char_u)(uint8_t)(type_str == NULL ? NUL : *type_str);
-    char *const pattern = tv_dict_get_string(d, "pattern", true);
-    char *text = tv_dict_get_string(d, "text", true);
-    if (text == NULL) {
-      text = xcalloc(1, 1);
-    }
-    bool valid = true;
-    if ((filename == NULL && bufnum == 0) || (lnum == 0 && pattern == NULL)) {
-      valid = false;
-    }
-
-    /* Mark entries with non-existing buffer number as not valid. Give the
-     * error message only once. */
-    if (bufnum != 0 && (buflist_findnr(bufnum) == NULL)) {
-      if (!did_bufnr_emsg) {
-        did_bufnr_emsg = TRUE;
-        EMSGN(_("E92: Buffer %" PRId64 " not found"), bufnum);
-      }
-      valid = false;
-      bufnum = 0;
-    }
-
-    // If the 'valid' field is present it overrules the detected value.
-    if (tv_dict_find(d, "valid", -1) != NULL) {
-      valid = (int)tv_dict_get_number(d, "valid");
-    }
-
-    int status = qf_add_entry(qi,
-                              qf_idx,
-                              NULL,      // dir
-                              (char_u *)filename,
-                              (char_u *)module,
-                              bufnum,
-                              (char_u *)text,
-                              lnum,
-                              col,
-                              vcol,      // vis_col
-                              (char_u *)pattern,   // search pattern
-                              nr,
-                              type,
-                              valid);
-
-    xfree(filename);
-    xfree(module);
-    xfree(pattern);
-    xfree(text);
-
-    if (status == FAIL) {
-      retval = FAIL;
+    retval = qf_add_entry_from_dict(qi, qf_idx, d, li == list->lv_first); 
+    if (retval == FAIL) {
       break;
     }
   });

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -212,6 +212,9 @@ typedef struct {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "quickfix.c.generated.h"
 #endif
+
+static char_u	*e_no_more_items = (char_u *)N_("E553: No more items");
+
 /* Quickfix window check helper macro */
 #define IS_QF_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref == NULL)
 /* Location list window check helper macro */
@@ -897,6 +900,14 @@ static bool qf_list_empty(qf_list_T *qfl )
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return qfl == NULL || qfl->qf_count <= 0;
+}
+
+/*
+ * Returns TRUE if the specified quickfix/location list is not empty and
+ * has valid entries.
+ */
+static int qf_list_has_valid_entries(qf_list_T *qfl) {
+  return !qf_list_empty(qfl) && !qfl->qf_nonevalid;
 }
 
 /*
@@ -2269,7 +2280,6 @@ static qfline_T *get_nth_valid_entry(qf_list_T *qfl, int errornr,
 {
   qfline_T *prev_qf_ptr;
   int prev_index;
-  static char_u *e_no_more_items = (char_u *)N_("E553: No more items");
   char_u *err = e_no_more_items;
 
   while (errornr--) {
@@ -4019,7 +4029,7 @@ size_t qf_get_size(exarg_T *eap)
   int prev_fnum = 0;
   size_t sz = 0;
   qfline_T *qfp;
-  size_t i;
+  int i;
   assert(qf_get_curlist(qi)->qf_count >= 0);
   qfl = qf_get_curlist(qi);
   FOR_ALL_QFL_ITEMS(qfl, qfp, i) {
@@ -4068,7 +4078,7 @@ int qf_get_cur_valid_idx(exarg_T *eap)
   qf_list_T *qfl = qf_get_curlist(qi);
 
   // Check if the list has valid errors.
-  if (qfl->qf_count <= 0 || qfl->qf_nonevalid) {
+  if (!qf_list_has_valid_entries(qfl)) {
     return 1;
   }
 
@@ -4107,7 +4117,7 @@ static size_t qf_get_nth_valid_entry(qf_list_T *qfl, size_t n, int fdo)
   FUNC_ATTR_NONNULL_ALL
 {
   // Check if the list has valid errors.
-  if (qfl->qf_count <= 0 || qfl->qf_nonevalid) {
+  if (!qf_list_has_valid_entries(qfl)) {
     return 1;
   }
 
@@ -4230,6 +4240,285 @@ void ex_cnext(exarg_T *eap)
 
   qf_jump(qi, dir, errornr, eap->forceit);
 }
+
+/*
+ * Find the first entry in the quickfix list 'qfl' from buffer 'bnr'.
+ * The index of the entry is stored in 'errornr'.
+ * Returns NULL if an entry is not found.
+ */
+static qfline_T * qf_find_first_entry_in_buf(qf_list_T *qfl, int bnr, int *errornr) {
+  qfline_T	*qfp = NULL;
+  int		idx = 0;
+
+  // Find the first entry in this file
+  FOR_ALL_QFL_ITEMS(qfl, qfp, idx)
+    if (qfp->qf_fnum == bnr)
+      break;
+
+  *errornr = idx;
+  return qfp;
+}
+
+/*
+ * Find the first quickfix entry on the same line as 'entry'. Updates 'errornr'
+ * with the error number for the first entry. Assumes the entries are sorted in
+ * the quickfix list by line number.
+ */
+static qfline_T * qf_find_first_entry_on_line(qfline_T *entry, int *errornr) {
+  while (!got_int
+      && entry->qf_prev != NULL
+      && entry->qf_fnum == entry->qf_prev->qf_fnum
+      && entry->qf_lnum == entry->qf_prev->qf_lnum)
+  {
+    entry = entry->qf_prev;
+    --*errornr;
+  }
+
+  return entry;
+}
+
+/*
+ * Find the last quickfix entry on the same line as 'entry'. Updates 'errornr'
+ * with the error number for the last entry. Assumes the entries are sorted in
+ * the quickfix list by line number.
+ */
+static qfline_T * qf_find_last_entry_on_line(qfline_T *entry, int *errornr) {
+  while (!got_int &&
+      entry->qf_next != NULL
+      && entry->qf_fnum == entry->qf_next->qf_fnum
+      && entry->qf_lnum == entry->qf_next->qf_lnum)
+  {
+    entry = entry->qf_next;
+    ++*errornr;
+  }
+
+  return entry;
+}
+
+/*
+ * Find the first quickfix entry below line 'lnum' in buffer 'bnr'.
+ * 'qfp' points to the very first entry in the buffer and 'errornr' is the
+ * index of the very first entry in the quickfix list.
+ * Returns NULL if an entry is not found after 'lnum'.
+ */
+static qfline_T * qf_find_entry_on_next_line(
+    int		bnr,
+    linenr_T	lnum,
+    qfline_T	*qfp,
+    int		*errornr)
+{
+  if (qfp->qf_lnum > lnum)
+    // First entry is after line 'lnum'
+    return qfp;
+
+  // Find the entry just before or at the line 'lnum'
+  while (qfp->qf_next != NULL
+      && qfp->qf_next->qf_fnum == bnr
+      && qfp->qf_next->qf_lnum <= lnum)
+  {
+    qfp = qfp->qf_next;
+    ++*errornr;
+  }
+
+  if (qfp->qf_next == NULL || qfp->qf_next->qf_fnum != bnr)
+    // No entries found after 'lnum'
+    return NULL;
+
+  // Use the entry just after line 'lnum'
+  qfp = qfp->qf_next;
+  ++*errornr;
+
+  return qfp;
+}
+
+/*
+ * Find the first quickfix entry before line 'lnum' in buffer 'bnr'.
+ * 'qfp' points to the very first entry in the buffer and 'errornr' is the
+ * index of the very first entry in the quickfix list.
+ * Returns NULL if an entry is not found before 'lnum'.
+ */
+static qfline_T * qf_find_entry_on_prev_line(
+    int		bnr,
+    linenr_T	lnum,
+    qfline_T	*qfp,
+    int		*errornr)
+{
+  // Find the entry just before the line 'lnum'
+  while (qfp->qf_next != NULL
+      && qfp->qf_next->qf_fnum == bnr
+      && qfp->qf_next->qf_lnum < lnum)
+  {
+    qfp = qfp->qf_next;
+    ++*errornr;
+  }
+
+  if (qfp->qf_lnum >= lnum)	// entry is after 'lnum'
+    return NULL;
+
+  // If multiple entries are on the same line, then use the first entry
+  qfp = qf_find_first_entry_on_line(qfp, errornr);
+
+  return qfp;
+}
+
+/*
+ * Find a quickfix entry in 'qfl' closest to line 'lnum' in buffer 'bnr' in
+ * the direction 'dir'.
+ */
+static qfline_T * qf_find_closest_entry(
+    qf_list_T	*qfl,
+    int		bnr,
+    linenr_T	lnum,
+    int		dir,
+    int		*errornr)
+{
+  qfline_T	*qfp;
+
+  *errornr = 0;
+
+  // Find the first entry in this file
+  qfp = qf_find_first_entry_in_buf(qfl, bnr, errornr);
+  if (qfp == NULL)
+    return NULL;		// no entry in this file
+
+  if (dir == FORWARD)
+    qfp = qf_find_entry_on_next_line(bnr, lnum, qfp, errornr);
+  else
+    qfp = qf_find_entry_on_prev_line(bnr, lnum, qfp, errornr);
+
+  return qfp;
+}
+
+/*
+ * Get the nth quickfix entry below the specified entry treating multiple
+ * entries on a single line as one. Searches forward in the list.
+ */
+static qfline_T * qf_get_nth_below_entry(qfline_T *entry, int *errornr, int n) {
+  while (n-- > 0 && !got_int)
+  {
+    qfline_T	*first_entry = entry;
+    int		first_errornr = *errornr;
+
+    // Treat all the entries on the same line in this file as one
+    entry = qf_find_last_entry_on_line(entry, errornr);
+
+    if (entry->qf_next == NULL
+        || entry->qf_next->qf_fnum != entry->qf_fnum)
+    {
+      // If multiple entries are on the same line, then use the first
+      // entry
+      entry = first_entry;
+      *errornr = first_errornr;
+      break;
+    }
+
+    entry = entry->qf_next;
+    ++*errornr;
+  }
+
+  return entry;
+}
+
+/*
+ * Get the nth quickfix entry above the specified entry treating multiple
+ * entries on a single line as one. Searches backwards in the list.
+ */
+static qfline_T * qf_get_nth_above_entry(qfline_T *entry, int *errornr, int n) {
+  while (n-- > 0 && !got_int)
+  {
+    if (entry->qf_prev == NULL
+        || entry->qf_prev->qf_fnum != entry->qf_fnum)
+      break;
+
+    entry = entry->qf_prev;
+    --*errornr;
+
+    // If multiple entries are on the same line, then use the first entry
+    entry = qf_find_first_entry_on_line(entry, errornr);
+  }
+
+  return entry;
+}
+
+/*
+ * Find the n'th quickfix entry adjacent to line 'lnum' in buffer 'bnr' in the
+ * specified direction.
+ * Returns the error number in the quickfix list or 0 if an entry is not found.
+ */
+static int qf_find_nth_adj_entry(qf_list_T *qfl, int bnr, linenr_T lnum, int n, int dir) {
+  qfline_T	*adj_entry;
+  int		errornr;
+
+  // Find an entry closest to the specified line
+  adj_entry = qf_find_closest_entry(qfl, bnr, lnum, dir, &errornr);
+  if (adj_entry == NULL)
+    return 0;
+
+  if (--n > 0)
+  {
+    // Go to the n'th entry in the current buffer
+    if (dir == FORWARD)
+      adj_entry = qf_get_nth_below_entry(adj_entry, &errornr, n);
+    else
+      adj_entry = qf_get_nth_above_entry(adj_entry, &errornr, n);
+  }
+
+  return errornr;
+}
+
+/*
+ * Jump to a quickfix entry in the current file nearest to the current line.
+ * ":cabove", ":cbelow", ":labove" and ":lbelow" commands
+ */
+void ex_cbelow(exarg_T *eap) {
+  qf_info_T	*qi;
+  qf_list_T	*qfl;
+  int		dir;
+  int		buf_has_flag;
+  int		errornr = 0;
+
+  if (eap->addr_count > 0 && eap->line2 <= 0)
+  {
+    EMSG(_(e_invrange));
+    return;
+  }
+
+  // Check whether the current buffer has any quickfix entries
+  if (eap->cmdidx == CMD_cabove || eap->cmdidx == CMD_cbelow)
+    buf_has_flag = BUF_HAS_QF_ENTRY;
+  else
+    buf_has_flag = BUF_HAS_LL_ENTRY;
+  if (!(curbuf->b_has_qf_entry & buf_has_flag))
+  {
+    EMSG(_(e_quickfix));
+    return;
+  }
+
+  if ((qi = qf_cmd_get_stack(eap, TRUE)) == NULL)
+    return;
+
+  qfl = qf_get_curlist(qi);
+  // check if the list has valid errors
+  if (!qf_list_has_valid_entries(qfl))
+  {
+    EMSG(_(e_quickfix));
+    return;
+  }
+
+  if (eap->cmdidx == CMD_cbelow || eap->cmdidx == CMD_lbelow)
+    dir = FORWARD;
+  else
+    dir = BACKWARD;
+
+  errornr = qf_find_nth_adj_entry(qfl, curbuf->b_fnum, curwin->w_cursor.lnum,
+      eap->addr_count > 0 ? eap->line2 : 0, dir);
+
+  if (errornr > 0)
+    qf_jump(qi, 0, errornr, FALSE);
+  else
+    EMSG(_(e_no_more_items));
+}
+
 
 /*
  * Return the autocmd name for the :cfile Ex commands
@@ -5756,17 +6045,17 @@ bool set_ref_in_quickfix(int copyID)
 /*
  * Return the autocmd name for the :cbuffer Ex commands
  */
-  static const char_u *
+  static char_u *
 cbuffer_get_auname(cmdidx_T cmdidx)
 {
   switch (cmdidx)
   {
-    case CMD_cbuffer:    return "cbuffer";
-    case CMD_cgetbuffer: return "cgetbuffer";
-    case CMD_caddbuffer: return "caddbuffer";
-    case CMD_lbuffer:    return "lbuffer";
-    case CMD_lgetbuffer: return "lgetbuffer";
-    case CMD_laddbuffer: return "laddbuffer";
+    case CMD_cbuffer:    return (char_u *)"cbuffer";
+    case CMD_cgetbuffer: return (char_u *)"cgetbuffer";
+    case CMD_caddbuffer: return (char_u *)"caddbuffer";
+    case CMD_lbuffer:    return (char_u *)"lbuffer";
+    case CMD_lgetbuffer: return (char_u *)"lgetbuffer";
+    case CMD_laddbuffer: return (char_u *)"laddbuffer";
     default:             return NULL;
   }
 }
@@ -5790,13 +6079,13 @@ static int cbuffer_process_args(
 
   if (buf == NULL)
   {
-    emsg(_(e_invarg));
+    EMSG(_(e_invarg));
     return FAIL;
   }
 
   if (buf->b_ml.ml_mfp == NULL)
   {
-    emsg(_("E681: Buffer is not loaded"));
+    EMSG(_("E681: Buffer is not loaded"));
     return FAIL;
   }
 
@@ -5809,7 +6098,7 @@ static int cbuffer_process_args(
   if (eap->line1 < 1 || eap->line1 > buf->b_ml.ml_line_count
       || eap->line2 < 1 || eap->line2 > buf->b_ml.ml_line_count)
   {
-    emsg(_(e_invrange));
+    EMSG(_(e_invrange));
     return FAIL;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -264,6 +264,154 @@ static struct fmtpattern
   { 'o', ".\\+" }
 };
 
+/*
+ * Convert an errorformat pattern to a regular expression pattern.
+ * See fmt_pat definition above for the list of supported patterns.
+ */
+static char_u * fmtpat_to_regpat(
+    char_u *efmp,
+    efm_T *fmt_ptr,
+    int	idx,
+    int	round,
+    char_u *ptr,
+    char_u *errmsg)
+{
+  char_u *srcptr;
+
+  if (fmt_ptr->addr[idx]) {
+    /* Each errorformat pattern can occur only once */
+    snprintf((char *)errmsg, CMDBUFFSIZE + 1,
+        _("E372: Too many %%%c in format string"), *efmp);
+    EMSG(errmsg);
+    return NULL;
+  }
+  if ((idx && idx < 6
+        && vim_strchr((char_u *)"DXOPQ", fmt_ptr->prefix) != NULL)
+      || (idx == 6
+        && vim_strchr((char_u *)"OPQ", fmt_ptr->prefix) == NULL)) {
+    snprintf((char *)errmsg, CMDBUFFSIZE + 1,
+        _("E373: Unexpected %%%c in format string"), *efmp);
+    EMSG(errmsg);
+    return NULL;
+  }
+  ++round;
+  fmt_ptr->addr[idx] = (char_u)round;
+  *ptr++ = '\\';
+  *ptr++ = '(';
+#ifdef BACKSLASH_IN_FILENAME
+  if (*efmp == 'f') {
+    /* Also match "c:" in the file name, even when
+     * checking for a colon next: "%f:".
+     * "\%(\a:\)\=" */
+    STRCPY(ptr, "\\%(\\a:\\)\\=");
+    ptr += 10;
+  }
+#endif
+  if (*efmp == 'f' && efmp[1] != NUL) {
+    if (efmp[1] != '\\' && efmp[1] != '%') {
+      /* A file name may contain spaces, but this isn't
+         + 	     * in "\f".  For "%f:%l:%m" there may be a ":" in
+         + 	     * the file name.  Use ".\{-1,}x" instead (x is
+         + 	     * the next character), the requirement that :999:
+         + 	     * follows should work. */
+      STRCPY(ptr, ".\\{-1,}");
+      ptr += 7;
+    } else {
+      /* File name followed by '\\' or '%': include as
+         + 	     * many file name chars as possible. */
+      STRCPY(ptr, "\\f\\+");
+      ptr += 4;
+    }
+  } else {
+    srcptr = (char_u *)fmt_pat[idx].pattern;
+    while ((*ptr = *srcptr++) != NUL) {
+      ++ptr;
+    }
+  }
+  *ptr++ = '\\';
+  *ptr++ = ')';
+
+  return ptr;
+}
+
+/*
+ * Convert a scanf like format in 'errorformat' to a regular expression.
+ */
+static char_u * scanf_fmt_to_regpat(
+    char_u *efm,
+    int	len,
+    char_u **pefmp,
+    char_u *ptr,
+    char_u *errmsg)
+{
+  char_u *efmp = *pefmp;
+
+  ++efmp;
+
+  if (*efmp == '[' || *efmp == '\\') {
+    if ((*ptr++ = *efmp) == '[') { /* %*[^a-z0-9] etc. */
+      if (efmp[1] == '^') {
+        ++efmp;
+        *ptr++ = *efmp;
+      }
+      if (efmp < efm + len) {
+        ++efmp;
+        *ptr++ = *efmp;	    /* could be ']' */
+        while (efmp < efm + len) {
+          efmp++;
+          if ((*ptr++ = *efmp) == ']') {
+            break;
+          }
+        }
+        if (efmp == efm + len) {
+          EMSG(_("E374: Missing ] in format string"));
+          return NULL;
+        }
+      }
+    }
+    else if (efmp < efm + len) { /* %*\D, %*\s etc. */
+      ++efmp;
+      *ptr++ = *efmp;
+    }
+    *ptr++ = '\\';
+    *ptr++ = '+';
+  } else {
+    /* TODO: scanf()-like: %*ud, %*3c, %*f, ... ? */
+    snprintf((char *)errmsg, CMDBUFFSIZE + 1,
+        _("E375: Unsupported %%%c in format string"), *efmp);
+    EMSG(errmsg);
+    return NULL;
+  }
+
+  *pefmp = efmp;
+
+  return ptr;
+}
+
+/*
+ * Analyze/parse an errorformat prefix.
+ */
+static int efm_analyze_prefix(char_u **pefmp, efm_T *fmt_ptr, char_u *errmsg) {
+  char_u *efmp = *pefmp;
+
+  if (vim_strchr((char_u *)"+-", *efmp) != NULL) {
+    fmt_ptr->flags = *efmp++;
+  }
+  if (vim_strchr((char_u *)"DXAEWICZGOPQ", *efmp) != NULL) {
+    fmt_ptr->prefix = *efmp;
+  } else {
+    snprintf((char *)errmsg, CMDBUFFSIZE + 1,
+        _("E376: Invalid %%%c in format string prefix"), *efmp);
+    EMSG(errmsg);
+    return FAIL;
+  }
+
+  *pefmp = efmp;
+
+  return OK;
+}
+
+
 // Converts a 'errorformat' string to regular expression pattern
 static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
                          char_u *regpat, char_u *errmsg)
@@ -282,89 +430,14 @@ static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
         }
       }
       if (idx < FMT_PATTERNS) {
-        if (fmt_ptr->addr[idx]) {
-          snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-                   _("E372: Too many %%%c in format string"), *efmp);
-          EMSG(errmsg);
-          return -1;
-        }
-        if ((idx
-             && idx < 6
-             && vim_strchr((char_u *)"DXOPQ", fmt_ptr->prefix) != NULL)
-            || (idx == 6
-                && vim_strchr((char_u *)"OPQ", fmt_ptr->prefix) == NULL)) {
-          snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-                   _("E373: Unexpected %%%c in format string"), *efmp);
-          EMSG(errmsg);
+        ptr = fmtpat_to_regpat(efmp, fmt_ptr, idx, round, ptr, errmsg);
+        if (ptr == NULL) {
           return -1;
         }
         round++;
-        fmt_ptr->addr[idx] = (char_u)round;
-        *ptr++ = '\\';
-        *ptr++ = '(';
-#ifdef BACKSLASH_IN_FILENAME
-        if (*efmp == 'f') {
-          // Also match "c:" in the file name, even when
-          // checking for a colon next: "%f:".
-          // "\%(\a:\)\="
-          STRCPY(ptr, "\\%(\\a:\\)\\=");
-          ptr += 10;
-        }
-#endif
-        if (*efmp == 'f' && efmp[1] != NUL) {
-          if (efmp[1] != '\\' && efmp[1] != '%') {
-            // A file name may contain spaces, but this isn't
-            // in "\f".  For "%f:%l:%m" there may be a ":" in
-            // the file name.  Use ".\{-1,}x" instead (x is
-            // the next character), the requirement that :999:
-            // follows should work.
-            STRCPY(ptr, ".\\{-1,}");
-            ptr += 7;
-          } else {
-            // File name followed by '\\' or '%': include as
-            // many file name chars as possible.
-            STRCPY(ptr, "\\f\\+");
-            ptr += 4;
-          }
-        } else {
-          char_u *srcptr = (char_u *)fmt_pat[idx].pattern;
-          while ((*ptr = *srcptr++) != NUL) {
-            ptr++;
-          }
-        }
-        *ptr++ = '\\';
-        *ptr++ = ')';
       } else if (*efmp == '*') {
-        if (*++efmp == '[' || *efmp == '\\') {
-          if ((*ptr++ = *efmp) == '[') {  // %*[^a-z0-9] etc.
-            if (efmp[1] == '^') {
-              *ptr++ = *++efmp;
-            }
-            if (efmp < efm + len) {
-              efmp++;
-              *ptr++ = *efmp;    // could be ']'
-              while (efmp < efm + len) {
-                efmp++;
-                if ((*ptr++ = *efmp) == ']') {
-                  break;
-                }
-              }
-              if (efmp == efm + len) {
-                EMSG(_("E374: Missing ] in format string"));
-                return -1;
-              }
-            }
-          } else if (efmp < efm + len) {  // %*\D, %*\s etc.
-            efmp++;
-            *ptr++ = *efmp;
-          }
-          *ptr++ = '\\';
-          *ptr++ = '+';
-        } else {
-          // TODO(vim): scanf()-like: %*ud, %*3c, %*f, ... ?
-          snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-                   _("E375: Unsupported %%%c in format string"), *efmp);
-          EMSG(errmsg);
+        ptr = scanf_fmt_to_regpat(efm, len, &efmp, ptr, errmsg);
+        if (ptr == NULL) {
           return -1;
         }
       } else if (vim_strchr((char_u *)"%\\.^$~[", *efmp) != NULL) {
@@ -374,15 +447,7 @@ static int efm_to_regpat(char_u *efm, int len, efm_T *fmt_ptr,
       } else if (*efmp == '>') {
         fmt_ptr->conthere = true;
       } else if (efmp == efm + 1) {             // analyse prefix
-        if (vim_strchr((char_u *)"+-", *efmp) != NULL) {
-          fmt_ptr->flags = *efmp++;
-        }
-        if (vim_strchr((char_u *)"DXAEWICZGOPQ", *efmp) != NULL) {
-          fmt_ptr->prefix = *efmp;
-        } else {
-          snprintf((char *)errmsg, CMDBUFFSIZE + 1,
-                   _("E376: Invalid %%%c in format string prefix"), *efmp);
-          EMSG(errmsg);
+        if (efm_analyze_prefix(&efmp, fmt_ptr, errmsg) == FAIL) {
           return -1;
         }
       } else {

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -163,6 +163,12 @@ endfunc
 func XageTests(cchar)
   call s:setup_commands(a:cchar)
 
+  if a:cchar == 'l'
+    " No location list for the current window
+    call assert_fails('lolder', 'E776:')
+    call assert_fails('lnewer', 'E776:')
+  endif
+
   let list = [{'bufnr': bufnr('%'), 'lnum': 1}]
   call g:Xsetlist(list)
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1955,6 +1955,18 @@ func Xproperty_tests(cchar)
     call g:Xsetlist([], 'r', {'items' : [{'filename' : 'F1', 'lnum' : 10, 'text' : 'L10'}]})
     call assert_equal('TestTitle', g:Xgetlist({'title' : 1}).title)
 
+    " Test for getting id of window associated with a location list window
+    if a:cchar == 'l'
+      only
+      call assert_equal(0, g:Xgetlist({'all' : 1}).filewinid)
+      let wid = win_getid()
+      Xopen
+      call assert_equal(wid, g:Xgetlist({'filewinid' : 1}).filewinid)
+      wincmd w
+      call assert_equal(0, g:Xgetlist({'filewinid' : 1}).filewinid)
+      only
+    endif
+
     " The following used to crash Vim with address sanitizer
     call g:Xsetlist([], 'f')
     call g:Xsetlist([], 'a', {'items' : [{'filename':'F1', 'lnum':10}]})
@@ -3067,7 +3079,17 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal('', g:Xgetlist({'title' : 0}).title)
   call assert_equal(0, g:Xgetlist({'winid' : 0}).winid)
   call assert_equal(0, g:Xgetlist({'changedtick' : 0}).changedtick)
-  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0, 'changedtick': 0}, g:Xgetlist({'all' : 0}))
+  if a:cchar == 'c'
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
+		  \ 'items' : [], 'nr' : 0, 'size' : 0,
+		  \ 'title' : '', 'winid' : 0, 'changedtick': 0},
+		  \ g:Xgetlist({'all' : 0}))
+  else
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
+		\ 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '',
+		\ 'winid' : 0, 'changedtick': 0, 'filewinid' : 0},
+		\ g:Xgetlist({'all' : 0}))
+  endif
 
   " Quickfix window with empty stack
   silent! Xopen
@@ -3100,7 +3122,16 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal('', g:Xgetlist({'id' : qfid, 'title' : 0}).title)
   call assert_equal(0, g:Xgetlist({'id' : qfid, 'winid' : 0}).winid)
   call assert_equal(0, g:Xgetlist({'id' : qfid, 'changedtick' : 0}).changedtick)
-  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0, 'changedtick' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
+  if a:cchar == 'c'
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
+		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
+		\ 'changedtick' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
+  else
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
+		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
+		\ 'changedtick' : 0, 'filewinid' : 0},
+		\ g:Xgetlist({'id' : qfid, 'all' : 0}))
+  endif
 
   " Non-existing quickfix list number
   call assert_equal('', g:Xgetlist({'nr' : 5, 'context' : 0}).context)
@@ -3112,7 +3143,16 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal('', g:Xgetlist({'nr' : 5, 'title' : 0}).title)
   call assert_equal(0, g:Xgetlist({'nr' : 5, 'winid' : 0}).winid)
   call assert_equal(0, g:Xgetlist({'nr' : 5, 'changedtick' : 0}).changedtick)
-  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0, 'changedtick' : 0}, g:Xgetlist({'nr' : 5, 'all' : 0}))
+  if a:cchar == 'c'
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
+		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
+		\ 'changedtick' : 0}, g:Xgetlist({'nr' : 5, 'all' : 0}))
+  else
+    call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
+		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
+		\ 'changedtick' : 0, 'filewinid' : 0},
+		\ g:Xgetlist({'nr' : 5, 'all' : 0}))
+  endif
 endfunc
 
 func Test_getqflist()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -37,6 +37,8 @@ func s:setup_commands(cchar)
     command! -nargs=* Xgrepadd <mods> grepadd <args>
     command! -nargs=* Xhelpgrep helpgrep <args>
     command! -nargs=0 -count Xcc <count>cc
+    command! -count=1 -nargs=0 Xbelow <mods><count>cbelow
+    command! -count=1 -nargs=0 Xabove <mods><count>cabove
     let g:Xgetlist = function('getqflist')
     let g:Xsetlist = function('setqflist')
     call setqflist([], 'f')
@@ -70,6 +72,8 @@ func s:setup_commands(cchar)
     command! -nargs=* Xgrepadd <mods> lgrepadd <args>
     command! -nargs=* Xhelpgrep lhelpgrep <args>
     command! -nargs=0 -count Xcc <count>ll
+    command! -count=1 -nargs=0 Xbelow <mods><count>lbelow
+    command! -count=1 -nargs=0 Xabove <mods><count>labove
     let g:Xgetlist = function('getloclist', [0])
     let g:Xsetlist = function('setloclist', [0])
     call setloclist(0, [], 'f')
@@ -3628,4 +3632,110 @@ func Test_curswant()
   1cc
   call assert_equal(getcurpos()[4], virtcol('.'))
   cclose | helpclose
+endfunc
+
+" Test for the :cbelow, :cabove, :lbelow and :labove commands.
+func Xtest_below(cchar)
+  call s:setup_commands(a:cchar)
+
+  " No quickfix/location list
+  call assert_fails('Xbelow', 'E42:')
+  call assert_fails('Xabove', 'E42:')
+
+  " Empty quickfix/location list
+  call g:Xsetlist([])
+  call assert_fails('Xbelow', 'E42:')
+  call assert_fails('Xabove', 'E42:')
+
+  call s:create_test_file('X1')
+  call s:create_test_file('X2')
+  call s:create_test_file('X3')
+  call s:create_test_file('X4')
+
+  " Invalid entries
+  edit X1
+  call g:Xsetlist(["E1", "E2"])
+  call assert_fails('Xbelow', 'E42:')
+  call assert_fails('Xabove', 'E42:')
+  call assert_fails('3Xbelow', 'E42:')
+  call assert_fails('4Xabove', 'E42:')
+
+  " Test the commands with various arguments
+  Xexpr ["X1:5:L5", "X2:5:L5", "X2:10:L10", "X2:15:L15", "X3:3:L3"]
+  edit +7 X2
+  Xabove
+  call assert_equal(['X2', 5], [bufname(''), line('.')])
+  call assert_fails('Xabove', 'E553:')
+  normal 2j
+  Xbelow
+  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  " Last error in this file
+  Xbelow 99
+  call assert_equal(['X2', 15], [bufname(''), line('.')])
+  call assert_fails('Xbelow', 'E553:')
+  " First error in this file
+  Xabove 99
+  call assert_equal(['X2', 5], [bufname(''), line('.')])
+  call assert_fails('Xabove', 'E553:')
+  normal gg
+  Xbelow 2
+  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  normal G
+  Xabove 2
+  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  edit X4
+  call assert_fails('Xabove', 'E42:')
+  call assert_fails('Xbelow', 'E42:')
+  if a:cchar == 'l'
+    " If a buffer has location list entries from some other window but not
+    " from the current window, then the commands should fail.
+    edit X1 | split | call setloclist(0, [], 'f')
+    call assert_fails('Xabove', 'E776:')
+    call assert_fails('Xbelow', 'E776:')
+    close
+  endif
+
+  " Test for lines with multiple quickfix entries
+  Xexpr ["X1:5:L5", "X2:5:1:L5_1", "X2:5:2:L5_2", "X2:5:3:L5_3",
+	      \ "X2:10:1:L10_1", "X2:10:2:L10_2", "X2:10:3:L10_3",
+	      \ "X2:15:1:L15_1", "X2:15:2:L15_2", "X2:15:3:L15_3", "X3:3:L3"]
+  edit +1 X2
+  Xbelow 2
+  call assert_equal(['X2', 10, 1], [bufname(''), line('.'), col('.')])
+  normal gg
+  Xbelow 99
+  call assert_equal(['X2', 15, 1], [bufname(''), line('.'), col('.')])
+  normal G
+  Xabove 2
+  call assert_equal(['X2', 10, 1], [bufname(''), line('.'), col('.')])
+  normal G
+  Xabove 99
+  call assert_equal(['X2', 5, 1], [bufname(''), line('.'), col('.')])
+  normal 10G
+  Xabove
+  call assert_equal(['X2', 5, 1], [bufname(''), line('.'), col('.')])
+  normal 10G
+  Xbelow
+  call assert_equal(['X2', 15, 1], [bufname(''), line('.'), col('.')])
+
+  " Invalid range
+  if a:cchar == 'c'
+    call assert_fails('-2cbelow', 'E553:')
+    " TODO: should go to first error in the current line?
+    0cabove
+  else
+    call assert_fails('-2lbelow', 'E553:')
+    " TODO: should go to first error in the current line?
+    0labove
+  endif
+
+  call delete('X1')
+  call delete('X2')
+  call delete('X3')
+  call delete('X4')
+endfunc
+
+func Test_cbelow()
+  call Xtest_below('c')
+  call Xtest_below('l')
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -540,6 +540,8 @@ func s:test_xhelpgrep(cchar)
 
   " Search for non existing help string
   call assert_fails('Xhelpgrep a1b2c3', 'E480:')
+  " Invalid regular expression
+  call assert_fails('Xhelpgrep \@<!', 'E480:')
 endfunc
 
 func Test_helpgrep()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1519,7 +1519,7 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
     newp->w_llist = NULL;
     newp->w_llist_ref = NULL;
   } else
-    copy_loclist(oldp, newp);
+    copy_loclist_stack(oldp, newp);
   newp->w_localdir = (oldp->w_localdir == NULL)
                      ? NULL : vim_strsave(oldp->w_localdir);
 


### PR DESCRIPTION
#### vim-patch:8.1.0010: efm_to_regpat() is too long

Problem:    efm_to_regpat() is too long.
Solution:   Split off three functions. (Yegappan Lakshmanan, closes vim/vim#2924)
https://github.com/vim/vim/commit/6bff719f7e472e918c60aa336de03e799b806c4f


#### vim-patch:8.1.0252: quickfix functions are too long

Problem:    Quickfix functions are too long.
Solution:   Refactor. (Yegappan Lakshmanan, closes vim/vim#2950)
https://github.com/vim/vim/commit/de3b3677f7eace66be454196db0fbf710cfc8c5e


#### vim-patch:8.1.0288: quickfix code uses cmdidx too often

Problem:    Quickfix code uses cmdidx too often.
Solution:   Add is_loclist_cmd(). (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/396659592fe039decc8c088694912067fe32a681


#### vim-patch:8.1.0330: the qf_add_entries() function is too long

Problem:    The qf_add_entries() function is too long.
Solution:   Split in two parts. (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/6f6ef7c1951b080843f3da049d3f5d0679de7348


#### vim-patch:8.1.0345: cannot get the window id associated with the location list

Problem:    Cannot get the window id associated with the location list.
Solution:   Add the "filewinid" argument to getloclist(). (Yegappan
            Lakshmanan, closes vim/vim#3202)
https://github.com/vim/vim/commit/c9cc9c78f21caba7ecb5c90403df5e19a57aa96a


#### vim-patch:8.1.0407: quickfix code mixes using the stack and a list pointer

Problem:    Quickfix code mixes using the stack and a list pointer.
Solution:   Use a list pointer in more places. (Yegappan Lakshmanan,
            closes vim/vim#3443)
https://github.com/vim/vim/commit/fe15b7dfa628d4edd683dae9528194c0e5510128


#### vim-patch:8.1.0434: copy_loclist() is too long

Problem:    copy_loclist() is too long.
Solution:   Split in multiple functions. (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/09037503ea5f957ad23121bc61e15e4bb1765edf


#### vim-patch:8.1.0469: too often indexing in qf_lists[]

Problem:    Too often indexing in qf_lists[].
Solution:   Use a qf_list_T pointer. (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/108e7b422b7b59153dd5af1fb75e83fa36ff3db4


#### vim-patch:8.1.0532: cannot distinguish between quickfix and location list

Problem:    Cannot distinguish between quickfix and location list.
Solution:   Add an explicit type variable. (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/2d67d307ee5dba911e8fbe73193bf596ebf76c1a


#### vim-patch:8.1.1006: repeated code in quickfix support

Problem:    Repeated code in quickfix support.
Solution:   Move code to functions. (Yegappan Lakshmanan, closes vim/vim#4091)
https://github.com/vim/vim/commit/4aa47b28f453b40d3b93ef209a3447c62b6f855b


#### vim-patch:8.1.1030: quickfix function arguments are inconsistent

Problem:    Quickfix function arguments are inconsistent.
Solution:   Pass a list pointer instead of info and index. (Yegappan
            Lakshmanan, closes vim/vim#4135)
https://github.com/vim/vim/commit/0398e00a1bf79e85223fb26938c8dd0d54883b77


#### vim-patch:8.1.1062: quickfix code is repeated

Problem:    Quickfix code is repeated.
Solution:   Define FOR_ALL_QFL_ITEMS(). Move some code to separate functions.
            (Yegappan Lakshmanan, closes vim/vim#4166)
https://github.com/vim/vim/commit/a16123a666b4656543614cb5bdaa69ea69f35d30


#### vim-patch:8.1.1098: quickfix code duplication

Problem:    Quickfix code duplication.
Solution:   Refactor the qf_init_ext() function. (Yegappan Lakshmanan,
            closes vim/vim#4193)
https://github.com/vim/vim/commit/95946f1209ad088bfe55c83256c299156c11d8e0


#### vim-patch:8.1.1112: duplicate code in quickfix file

Problem:    Duplicate code in quickfix file.
Solution:   Move code into functions. (Yegappan Lakshmanan, closes vim/vim#4207)
https://github.com/vim/vim/commit/87f59b09ea4b9af2712598374a6044f5fa1b54a4


#### vim-patch:8.1.1256: cannot navigate through errors relative to the cursor

Problem:    Cannot navigate through errors relative to the cursor.
Solution:   Add :cabove, :cbelow, :labove and :lbelow. (Yegappan Lakshmanan,
            closes vim/vim#4316)
https://github.com/vim/vim/commit/3ff33114d70fc0f7e9c3187c5fec9028f6499cf3